### PR TITLE
update spring-security schema version in beans.xml

### DIFF
--- a/modules/ROOT/pages/spring/spring-module.adoc
+++ b/modules/ROOT/pages/spring/spring-module.adoc
@@ -113,7 +113,7 @@ In the Spring configuration file, an Authentication Manager must be defined, for
     http://www.springframework.org/schema/context
     http://www.springframework.org/schema/context/spring-context-4.1.xsd
     http://www.springframework.org/schema/security
-    http://www.springframework.org/schema/security/spring-security-4.1.xsd">
+    http://www.springframework.org/schema/security/spring-security-4.2.xsd">
 
   <ss:authentication-manager alias="authenticationManager">
     <ss:authentication-provider>


### PR DESCRIPTION
For spring-security, dependency version is 4.2.6.RELEASE. But the beans.xml given in the doc references to spring-security-4.1.xsd in schemaLocation. This needs to be changed to spring-security-4.2.xsd to build the project.