### PR TITLE
Remove the Trasaction type in the IBM MQ publish

### DIFF
--- a/modules/ROOT/pages/ibm/ibm-mq-transactions.adoc
+++ b/modules/ROOT/pages/ibm/ibm-mq-transactions.adoc
@@ -141,8 +141,8 @@ Or join a scoped transaction:
 	transactionType="XA"/>
         <ibm-mq:publish config-ref="config"
 	destination="${shipmentService}"
-	transactionalAction="ALWAYS_JOIN"
-	transactionType="XA"/>
+	transactionalAction="ALWAYS_JOIN"/>
+	
         <ibm-mq:publish-consume config-ref="IBM_MQ_Config"
 	destination="${invoicesVerificationService}"/>
         <validation:is-true expression="#[payload]"/>


### PR DESCRIPTION
A couple of customers consider that always was needed to add the transaction type for joining.

This example worked perfectly.
		<try doc:name="Try" doc:id="e1abce8c-25f5-46bd-b532-a74d14aa5bec" transactionalAction="ALWAYS_BEGIN" transactionType="XA">
			<ibm-mq:publish doc:name="Copy_of_Publish" doc:id="124e3412-f2a8-4761-bac3-6d97a7cdc7b8" config-ref="IBM_MQ_Config_XA" destination="DEV.QUEUE.2" />
		</try>

Customer Statement:
Documentation at https://docs.mulesoft.com/connectors/ibm/ibm-mq-transactions is showing incorrect information under "XA transactions" stating that ibm-mq:publish can have transactionType attribute which is incorrect as it is not allowed. Though I have not given transactionType it is able to join XA transaction. if this is correct, you may consider changing the documentation to provide correct information.