### PR TITLE
IN-OUT and OUT parameters must be typed

### DIFF
--- a/modules/ROOT/pages/db/db-connector-sp.adoc
+++ b/modules/ROOT/pages/db/db-connector-sp.adoc
@@ -37,8 +37,9 @@ It is possible to invoke stored procedures which combine, input, output and inpu
         }]
     </db:input-parameters>
     <db:output-parameters>
-        <db:output-parameter key="result1"/>
-        <db:output-parameter key="result2"/>
+        <db:output-parameter key="result1" type="INTEGER"/>
+        <db:output-parameter key="result2" type="INTEGER"/>
+        <db:output-parameter key="myInt" type="INTEGER"/>
     </db:output-parameters>
 </db:stored-procedure>
 ----


### PR DESCRIPTION
If we not type in-out and out parameters we will face a jdbc error invalid coloumn type. see JIRA SE-10405