### PR TITLE
Fixed typo for consume and publish-consume operations

### DIFF
--- a/modules/ROOT/pages/vm/vm-reference.adoc
+++ b/modules/ROOT/pages/vm/vm-reference.adoc
@@ -62,7 +62,7 @@ Returns instances of VMConnection
 `<vm:consume>`
 
 +++
-Pull one message from a queue. If a message is not immediately available, it will wait up to the configured queueTimeout, after which a VM:QUEUE_TIMEOUT error will be thrown. <p> The queue on which the content is published has to be one for which a <vm:listener> <b>doesn't </b> exists. Consuming from queues on which a <vm:listener> exists is not allowed.
+Pull one message from a queue. If a message is not immediately available, it will wait up to the configured queueTimeout, after which a VM:QUEUE_TIMEOUT error will be thrown. <p> The queue on which the content is published has to be one for which a `<vm:listener>` <b>doesn't </b> exists. Consuming from queues on which a `<vm:listener>` exists is not allowed.
 +++
 
 ==== Parameters
@@ -157,7 +157,7 @@ Publishes the given content into the queue of the given queueName.
 `<vm:publish-consume>`
 
 +++
-Publishes the given content into a queue, and then awaits up to the queueTimeout for a response to be supplied on a temporal reply-To queue that this operation automatically creates. <p> The temporal reply queue is automatically disposed after a response is received or the timeout expires. <p> The queue on which the content is published has to be one for which a <vm:listener> <b>doesn't </b> exists. Consuming from queues on which a <vm:listener> exists is not allowed.
+Publishes the given content into a queue, and then awaits up to the queueTimeout for a response to be supplied on a temporal reply-To queue that this operation automatically creates. <p> The temporal reply queue is automatically disposed after a response is received or the timeout expires. <p> The queue on which the content is published has to be one for which a `<vm:listener>` <b>doesn't </b> exists. Consuming from queues on which a `<vm:listener>` exists is not allowed.
 +++
 
 ==== Parameters

--- a/modules/ROOT/pages/vm/vm-reference.adoc
+++ b/modules/ROOT/pages/vm/vm-reference.adoc
@@ -1,11 +1,7 @@
-= VM Connector Documentation Reference
+= VM Connector Reference
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:last-update-label!:
-:docinfo:
-:source-highlighter: coderay
-:icons: font
 
 +++
 The VM Connector is used for intra/inter app communication. The communication is done through asynchronous queues, which can be either transient or persistent. Transient queues are faster, but not reliable in the case of a system crash. Persistent queues, on the other hand are slower but reliable. When running on a single instance, persistent queues work by serializing and storing the contents into disk. When running in cluster mode, persistent queues are backed by the memory grid instead. This means that when a flow uses the VM connector to publish content to a queue, the Runtime will decide whether to process that message in the same origin node or to send it out to the cluster for another node to pick it up. This is an easy way to distribute load across the cluster. In either way, transactions are always supported. Each config defines its own set of queues. Those queues are only visible to components referencing that config.
@@ -62,7 +58,7 @@ Returns instances of VMConnection
 `<vm:consume>`
 
 +++
-Pull one message from a queue. If a message is not immediately available, it will wait up to the configured queueTimeout, after which a VM:QUEUE_TIMEOUT error will be thrown. <p> The queue on which the content is published has to be one for which a `<vm:listener>` <b>doesn't </b> exists. Consuming from queues on which a `<vm:listener>` exists is not allowed.
+Pull one message from a queue. If a message is not immediately available, it will wait up to the configured queueTimeout, after which a VM:QUEUE_TIMEOUT error will be thrown. The queue on which the content is published has to be one for which a `<vm:listener>` doesn't exists. Consuming from queues on which a `<vm:listener>` exists is not allowed.
 +++
 
 ==== Parameters
@@ -157,7 +153,7 @@ Publishes the given content into the queue of the given queueName.
 `<vm:publish-consume>`
 
 +++
-Publishes the given content into a queue, and then awaits up to the queueTimeout for a response to be supplied on a temporal reply-To queue that this operation automatically creates. <p> The temporal reply queue is automatically disposed after a response is received or the timeout expires. <p> The queue on which the content is published has to be one for which a `<vm:listener>` <b>doesn't </b> exists. Consuming from queues on which a `<vm:listener>` exists is not allowed.
+Publishes the given content into a queue, and then awaits up to the queueTimeout for a response to be supplied on a temporal reply-To queue that this operation automatically creates. The temporal reply queue is automatically disposed after a response is received or the timeout expires. The queue on which the content is published has to be one for which a `<vm:listener>` doesn't exists. Consuming from queues on which a `<vm:listener>` exists is not allowed.
 +++
 
 ==== Parameters
@@ -211,7 +207,7 @@ Publishes the given content into a queue, and then awaits up to the queueTimeout
 `<vm:listener>`
 
 +++
-A source which creates and listens on a VM queues. <p> VM queues are created by placing listeners on them, which is why this listener contains parameters on the queue's behavior, such as it being persistent or not, the max capacity, etc.
+A source which creates and listens on a VM queues. VM queues are created by placing listeners on them, which is why this listener contains parameters on the queue's behavior, such as it being persistent or not, the max capacity, etc.
 +++
 
 ==== Parameters
@@ -272,20 +268,22 @@ A source which creates and listens on a VM queues. <p> VM queues are created by 
 [[reconnect]]
 === Reconnect
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Frequency a| Number | How often (in ms) to reconnect |  |
-| Count a| Number | How many reconnection attempts to make |  |
+| Frequency a| Number | How often in milliseconds to reconnect. | |
+| Count a| Number | How many reconnection attempts to make. | |
+| blocking |Boolean |If false, the reconnection strategy runs in a separate, non-blocking thread. |true |
 |===
 
 [[reconnect-forever]]
 === Reconnect Forever
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Frequency a| Number | How often (in ms) to reconnect |  |
+| Frequency a| Number | How often in milliseconds to reconnect. | |
+| blocking |Boolean |If false, the reconnection strategy runs in a separate, non-blocking thread. |true |
 |===
 
 [[queue]]


### PR DESCRIPTION
Fixed typo for consume and publish-consume operations where <vm:listener> was not visible in HTML view