### PR TITLE
DOCS-3806 note + edits

### DIFF
--- a/modules/ROOT/pages/file/file-connector.adoc
+++ b/modules/ROOT/pages/file/file-connector.adoc
@@ -10,14 +10,12 @@ The File connector handles files and folders on a locally mounted file system. I
 // INCLUDE FOR file, ftp, and sftp connectors
 include::partial$common-file-actions.adoc[]
 
-For information on error conditions, see the 
+For information on error conditions, see the xref:file-documentation.adoc[File Connector Reference].
 
 [[connection_settings]]
 == Configure the File Connector
 
 The File connector does not always require configuration. However, it is good practice to define one. The most important configuration parameter is the Working Directory (`workingDir`), which is the path to a directory that is treated as the root of every relative path that you specify with this connector. If you do not provide a working directory, the connector configuration defaults to the value of the `user.home` system property. If the system property is not set, the connector  fails to initialize.
-
-For information on which exceptions each File connector operation can throw, see the xref:file-documentation.adoc[File Connector Reference].
 
 You can also set the default encoding to use when writing files. It defaults to Mule runtime's default encoding. If you use any File connector operations without referencing a configuration, the operation uses the default values.
 

--- a/modules/ROOT/pages/file/file-connector.adoc
+++ b/modules/ROOT/pages/file/file-connector.adoc
@@ -2,8 +2,6 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:keywords: file, connector, matcher, directory, listener
-
 
 Release Notes: xref:release-notes::connector/connector-file.adoc[File Connector Release Notes]
 
@@ -12,12 +10,16 @@ The File connector handles files and folders on a locally mounted file system. I
 // INCLUDE FOR file, ftp, and sftp connectors
 include::partial$common-file-actions.adoc[]
 
+For information on error conditions, see the 
+
 [[connection_settings]]
-== Configuring the File Connector
+== Configure the File Connector
 
-The File connector does not always require configuration. However, it is good practice to define one. The most important configuration parameter is the Working Directory (`workingDir`), which is the path to a directory that is treated as the root of every relative path that you specify with this connector. If you do not provide a working directory, the connector configuration will default to the value of the `user.home` system property. If the system property is not set, the connector will fail to initialize.
+The File connector does not always require configuration. However, it is good practice to define one. The most important configuration parameter is the Working Directory (`workingDir`), which is the path to a directory that is treated as the root of every relative path that you specify with this connector. If you do not provide a working directory, the connector configuration defaults to the value of the `user.home` system property. If the system property is not set, the connector  fails to initialize.
 
-You can also set the default encoding to use when writing files. It defaults to Mule runtime's default encoding. If you use any File connector operations without referencing a configuration, the operation will use the default values.
+For information on which exceptions each File connector operation can throw, see the xref:file-documentation.adoc[File Connector Reference].
+
+You can also set the default encoding to use when writing files. It defaults to Mule runtime's default encoding. If you use any File connector operations without referencing a configuration, the operation uses the default values.
 
 This example sets a working directory for the File connector:
 
@@ -34,14 +36,9 @@ include::partial$common-file-attributes.adoc[]
 [[see_also]]
 == See Also
 
-xref:file/file-documentation.adoc[File Connector Documentation Reference]
-
-xref:file/file-read.adoc[To Read Files]
-
-xref:file/file-write.adoc[To Write Files]
-
-xref:file/file-list.adoc[To List Files]
-
-xref:file/file-on-new-file.adoc[To Listen for New or Modified Files]
-
-xref:file/file-copy-move.adoc[To Copy or Move Files]
+* xref:file/file-documentation.adoc[File Connector Documentation Reference]
+* xref:file/file-read.adoc[Read Files]
+* xref:file/file-write.adoc[Write Files]
+* xref:file/file-list.adoc[List Files]
+* xref:file/file-on-new-file.adoc[Listen for New or Modified Files]
+* xref:file/file-copy-move.adoc[Copy or Move Files]

--- a/modules/ROOT/pages/file/file-connector.adoc
+++ b/modules/ROOT/pages/file/file-connector.adoc
@@ -10,7 +10,7 @@ The File connector handles files and folders on a locally mounted file system. I
 // INCLUDE FOR file, ftp, and sftp connectors
 include::partial$common-file-actions.adoc[]
 
-For information on error conditions, see the xref:file-documentation.adoc[File Connector Reference].
+For information on error conditions, see the xref:file/file-documentation.adoc[File Connector Reference].
 
 [[connection_settings]]
 == Configure the File Connector


### PR DESCRIPTION
For more info, see https://www.mulesoft.org/jira/browse/DOCS-3806 -- this feedback jira asks for a throws section, which is non-standard for connector guides and is already covered in the File connector reference (https://docs.mulesoft.com/connectors/file/file-documentation). I just added a link to the reference, which is in the same folder as this guide.