### PR TITLE
DOCS-3805 fix

### DIFF
--- a/modules/ROOT/pages/common/common-file-attributes.adoc
+++ b/modules/ROOT/pages/common/common-file-attributes.adoc
@@ -5,4 +5,10 @@ endif::[]
 
 // Included in sftp-connector.adoc, ftp-connector.adoc, file-connector.adoc
 
-When reading or listing files, you might be interested in the file's metadata (for example, the file name, full path, size, timestamp, and so on). The connector uses the Mule Message Attributes to access this information. More information about file attributes are available in the <<see_also, reference>> for this connector.
+When reading or listing files, you might be interested in the file's metadata (for example, the file name, full path, size, timestamp, and so on). The connector uses the Mule Message Attributes to access this information. 
+
+////
+The following link is broken when people access this file directly - See DOCS-3805 for more info. Commenting out until someone determines how to fix this.
+
+More information about file attributes are available in the <<see_also, reference>> for this connector.
+////


### PR DESCRIPTION
Commented out a bogus link per DOCS-3805 (https://www.mulesoft.org/jira/browse/DOCS-3805) -- Someone created a bunch of common doc files and forgot that people can access the files directly. I commented out the broken link and left a note for whoever owns this.