### PR TITLE
Changed occurrences of "invalidate" to "retrieve"

### DIFF
--- a/modules/ROOT/pages/oauth/oauth-documentation.adoc
+++ b/modules/ROOT/pages/oauth/oauth-documentation.adoc
@@ -2,10 +2,6 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:last-update-label!:
-:docinfo:
-:source-highlighter: coderay
-:icons: font
 
 +++
 An extension to hook OAuth2 to HTTP extension connectors.
@@ -59,7 +55,7 @@ Clears the oauth context for a token manager and a resource owner id.
 `<oauth:retrieve-access-token>`
 
 +++
-Returns the access token of the token manager for the parametrized resource owner ID
+Returns the access token of the token manager for the parameterized resource owner ID
 +++
 
 ==== Parameters
@@ -115,7 +111,7 @@ Returns the value of the parameter that was extracted during the dance from the 
 `<oauth:retrieve-expires-in>`
 
 +++
-Returns the expiration of the oauth context for the parametrized resource owner ID
+Returns the expiration of the oauth context for the parameterized resource owner ID
 +++
 
 ==== Parameters
@@ -143,7 +139,7 @@ Returns the expiration of the oauth context for the parametrized resource owner 
 `<oauth:retrieve-refresh-token>`
 
 +++
-Returns the refresh token of the oauth context for the parametrized resource owner ID
+Returns the refresh token of the oauth context for the parameterized resource owner ID
 +++
 
 ==== Parameters
@@ -171,7 +167,7 @@ Returns the refresh token of the oauth context for the parametrized resource own
 `<oauth:retrieve-state>`
 
 +++
-Returns the state of the oauth context for the parametrized resource owner ID
+Returns the state of the oauth context for the parameterized resource owner ID
 +++
 
 ==== Parameters

--- a/modules/ROOT/pages/oauth/oauth-documentation.adoc
+++ b/modules/ROOT/pages/oauth/oauth-documentation.adoc
@@ -67,7 +67,7 @@ Returns the access token of the token manager for the parametrized resource owne
 |===
 | Name | Type | Description | Default Value | Required
 | Token Manager a| <<token-manager-config>> |  +++The token manager which holds the access token.+++ |  | *x*{nbsp}
-| Resource Owner Id a| String |  +++The resource owner id to invalidate. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
+| Resource Owner Id a| String |  +++The resource owner id to retrieve. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
 | Output Mime Type a| String |  +++The mime type of the payload that this operation outputs.+++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
@@ -95,7 +95,7 @@ Returns the value of the parameter that was extracted during the dance from the 
 |===
 | Name | Type | Description | Default Value | Required
 | Token Manager a| <<token-manager-config>> |  +++The token manager which holds the access token.+++ |  | *x*{nbsp}
-| Resource Owner Id a| String |  +++The resource owner id to invalidate. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
+| Resource Owner Id a| String |  +++The resource owner id to retrieve. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
 | Key a| String |  +++to look for in the elements that has been extracted after the previous OAuth dance.+++ |  | *x*{nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
@@ -123,7 +123,7 @@ Returns the expiration of the oauth context for the parametrized resource owner 
 |===
 | Name | Type | Description | Default Value | Required
 | Token Manager a| <<token-manager-config>> |  +++The token manager which holds the access token.+++ |  | *x*{nbsp}
-| Resource Owner Id a| String |  +++The resource owner id to invalidate. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
+| Resource Owner Id a| String |  +++The resource owner id to retrieve. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
 | Output Mime Type a| String |  +++The mime type of the payload that this operation outputs.+++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
@@ -151,7 +151,7 @@ Returns the refresh token of the oauth context for the parametrized resource own
 |===
 | Name | Type | Description | Default Value | Required
 | Token Manager a| <<token-manager-config>> |  +++The token manager which holds the refresh token.+++ |  | *x*{nbsp}
-| Resource Owner Id a| String |  +++The resource owner id to invalidate. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
+| Resource Owner Id a| String |  +++The resource owner id to retrieve. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
 | Output Mime Type a| String |  +++The mime type of the payload that this operation outputs.+++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
@@ -179,7 +179,7 @@ Returns the state of the oauth context for the parametrized resource owner ID
 |===
 | Name | Type | Description | Default Value | Required
 | Token Manager a| <<token-manager-config>> |  +++The token manager which holds the access token.+++ |  | *x*{nbsp}
-| Resource Owner Id a| String |  +++The resource owner id to invalidate. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
+| Resource Owner Id a| String |  +++The resource owner id to retrieve. This attribute is only allowed for authorization code grant type.+++ |  +++default+++ | {nbsp}
 | Output Mime Type a| String |  +++The mime type of the payload that this operation outputs.+++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}


### PR DESCRIPTION
Descriptions for all occurrences of "Resource Owner Id" were clearly copied/pasted from invalidateOauthContext. This edit replaces "invalidate" with "retrieve" for other than the invalidateOauthContext operation. All edits should be further reviewed to ensure the remaining copied/pasted information is actually correct for the retrieve operations.