### PR TITLE
DOCS-3487 fix

### DIFF
--- a/modules/ROOT/pages/xml/xml-module.adoc
+++ b/modules/ROOT/pages/xml/xml-module.adoc
@@ -2,7 +2,6 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:keywords: XML, xpath, xslt, xquery, XSD, validation
 
 Release Notes: xref:release-notes::mule-runtime/module-xml.adoc[XML Module Release Notes]
 
@@ -19,6 +18,12 @@ To use the XML module, you simply add it to your Mule app through the Studio or 
     <classifier>mule-plugin</classifier>
 </dependency>
 ----
+
+== Validate Against a Schema
+
+When using the XML Module to validate against a schema that has references to other local schema files, validation can fail because the access was restricted by the `expandEntities` as it was using the default value of NEVER. The error message is: The supplied schemas were not valid. schema_reference: Failed to read schema document `NMVS_Composite_Types.xsd`, because `file` access is not allowed due to restriction set by the accessExternalSchema property.
+
+You can eliminate this issue by adding `expandEntities="INTERNAL"` to the `xml-module:config` element. 
 
 == See Also
 


### PR DESCRIPTION
See https://www.mulesoft.org/jira/browse/DOCS-3487
Jira Description:
We had a customer that was using the XML Module to validate against a schema. This schema had references to other local schema files. Validation failed because the access was restricted by the expandEntities as it was using the default value of NEVER. The customer, after being instructed to provide this value, mentioned that Adding expandEntities="INTERNAL" to the xml-module:config made the difference! The documentation does not describe this config option - or at least not the impact of it in combination with XML Schema's. I'd suggest to add some documentation here. We mention the attribute in the reference page but it's true that we don't clarify the relation with loading local schema files.

Case is 00203853 and the error message The supplied schemas were not valid. schema_reference: Failed to read schema document 'NMVS_Composite_Types.xsd', because 'file' access is not allowed due to restriction set by the accessExternalSchema property.