### PR TITLE
DOCS-3844 fix

### DIFF
--- a/modules/ROOT/pages/ftp/ftp-read.adoc
+++ b/modules/ROOT/pages/ftp/ftp-read.adoc
@@ -27,5 +27,6 @@ include::partial$common-read-operation.adoc[]
 // == File Locking SHARED BY FTP AND SFTP only
 include::partial$common-file-lock.adoc[]
 
-//== STREAMING INCLUDE in File, FTP, and SFTP Connector docs
-include::partial$common-streaming.adoc[]
+The Read operation makes use of the repeatable streams functionality introduced in Mule 4. The operation returns a list of messages, where each message represents a file in the list and holds a stream to the file. A stream is repeatable by default.
+
+For more information on this topic, see xref:4.1@mule-runtime::streaming-about.adoc[Streaming in Mule 4].


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/DOCS-3844
The previously _partial reference to https://raw.githubusercontent.com/mulesoft/docs-connectors/latest/modules/ROOT/pages/_partials/common-streaming.adoc was the error that DOCS-3844 is about -- Using the "List operation" in the _partial file was completely incorrect in the context of thae Read operation. Solution was to copy the partial text to this file and change "List" to "Read".