### PR TITLE
Docs 4163 Salesforce Reference

### DIFF
--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
@@ -6255,3 +6255,7 @@ overwritten). For information on IDs, see ID Field Type. |  |
 | Success a| Boolean |  |  | 
 |===
 
+== See Also
+
+* https://forums.mulesoft.com[MuleSoft Forum]
+* https://support.mulesoft.com/s/knowledge[Knowledge Base Articles]

--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
@@ -73,12 +73,12 @@ Required: No
 Type: Number +
 Default Value: None +
 Required: No
-| Username |Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.
+| Username | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.
 
 Type: String +
 Default Value: None +
 Required: No
-| Password |Password used to authenticate against the proxy.
+| Password | Password used to authenticate against the proxy.
 
 Type: String +
 Default Value: None +
@@ -103,7 +103,7 @@ Required: No
 Type: String +
 Default Value: `+https://login.salesforce.com/services/Soap/u/43.0+` +
 Required: No
-| Reconnection a| | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
+| Reconnection | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
 
 Type: <<Reconnection>>  +
 Default Value: None +

--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
@@ -302,7 +302,7 @@ Required: No
 
 [%header,cols="30a,70a"]
 |===
-| Name |Description
+| Name | Description
 | Advanced Reconnection Params |
 
 Type: <<AdvancedReconnectionParams>> +
@@ -352,7 +352,7 @@ Required: No
 
 Type: ObjectStore +
 Default Value: None +
-Required: No|
+Required: No
 | Batch SObject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
 
 Type: Number +
@@ -408,12 +408,12 @@ Required: Yes
 Type: String +
 Default Value: None +
 Required: No
-| Token Endpoint |URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL).
+| Token Endpoint | URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL).
 
 Type: String +
 Default Value: `+https://login.salesforce.com/services/oauth2/token+` +
 Required: No
-| Reconnection |When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
+| Reconnection | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
 
 Type: <<Reconnection>> +
 Default Value: None +

--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
@@ -636,7 +636,7 @@ Required: No
 Type: String +
 Default Value: None +
 Required: No
-| Read Timeout Specifies the amount of time in milliseconds that the consumer waits for a response before it times out. Default value is 0, which means infinite.
+| Read Timeout | Specifies the amount of time in milliseconds that the consumer waits for a response before it times out. Default value is 0, which means infinite.
 
 Type: Number +
 Default Value: 0 +

--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference.adoc
@@ -4,29 +4,54 @@ Support Category: Select
 
 Salesforce Connector version 9.5.1
 
-== Configurations
----
+
 [[sfdc-config]]
-== Config
+== Default Configuration
 
 === Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-|Name | String | The name for this configuration. Connectors reference the configuration with this name. | |x
-| Connection a| * <<sfdc-config_basic, Username Password (Deprecated)>>
+| Name |Description
+|Name |The name for this configuration. Connectors reference the configuration with this name.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Connection | The connection types that can be provided to this configuration.
+
+Type: 
+
+* <<sfdc-config_basic, Username Password (Deprecated)>>
 * <<sfdc-config_cached-basic, Cached Basic Username Password>>
 * <<sfdc-config_cached-oauth-user-pass, Cached OAuth Username Password>>
 * <<sfdc-config_config-with-oauth, OAuth v2.0>>
 * <<sfdc-config_oauth-jwt, OAuth JWT>>
 * <<sfdc-config_oauth-saml, OAuth SAML>>
 * <<sfdc-config_oauth-user-pass, OAuth Username Password>>
- | The connection types that can be provided to this configuration. | |x
-| Expiration Policy a| <<ExpirationPolicy>> | Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. The runtime actually purges the instances when it sees fit. |  |
-| Fetch All Apex SOAP Metadata a| Boolean | If checked then Datasense is performed for all Apex classes in the organization, otherwise it is performed only for the classes in Apex class names. If the organization contains a lot of Apex classes this might cause ConnectionTimeout during Datasense. Default value is false | false |
-| Fetch All Apex REST Metadata a| Boolean | If checked then Datasense will be performed for all Apex classes in the organization else Datasense will be performed only for the classes in Apex class names. If the organization contains many Apex classes this could cause ConnectionTimeout during Datasense. Default value is false | false |
-| Apex Class Names a| Array of String | List of Apex class names involved in metadata retrieval via Datasense. |  |
+
+Default Value: None +
+Required: Yes
+| Expiration Policy | Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform expires an instance at the exact moment that it becomes eligible. The runtime actually purges the instances when it sees fit.
+
+Type: <<ExpirationPolicy>> +
+Default Value: None +
+Required: No
+| Fetch All Apex SOAP Metadata | If checked then Datasense is performed for all Apex classes in the organization, otherwise it is performed only for the classes in Apex class names. If the organization contains a lot of Apex classes this might cause ConnectionTimeout during Datasense. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Fetch All Apex REST Metadata |If checked then DataSense is performed for all Apex classes in the organization. Otherwise, DataSense is performed only for the classes in Apex class names. If the organization contains many Apex classes, this could cause a ConnectionTimeout during DataSense. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Apex Class Names | List of Apex class names involved in metadata retrieval via DataSense.
+
+Type: Array of String +
+Default Value: None +
+Required: Yes
 |===
 
 == Connection Types
@@ -35,31 +60,119 @@ Salesforce Connector version 9.5.1
 
 ==== Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-| Host a| String | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified. |  |
-| Port a| Number | Port of the proxy. If host is set then this property must be set and cannot be a negative number. |  |
-| Username a| String | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified. |  |
-| Password a| String | Password used to authenticate against the proxy. |  |
-| Username a| String | Username used to initialize the session. |  |x
-| Password a| String | Password used to authenticate the user. |  |x
-| Security Token a| String | User's security token. It can be omitted if your IP has been whitelisted on Salesforce. |  |
-| Authorization URL a| String | Web service URL responsible for user authentication. This is the URL for the endpoint that is configured to handle SOAP authentication requests. | `+https://login.salesforce.com/services/Soap/u/43.0+` |
-| Reconnection a| <<Reconnection>> | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
-| Pooling Profile a| <<PoolingProfile>> | Characteristics of the connection pool. |  |
-| Read Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite. | 0|
-| Connection Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite. | 0 |
-| Assignment Rule Id a| String |  |  |
-| Client Id a| String | Client ID for partners. |  |
-| Time Object Store a| ObjectStore | An ObjectStore instance. |  |
-| Batch Sobject Max Depth a| Number | Creating a batch creates SObjects using this value for the MAX_DEPTH check. | 5 |
-| Session Id a| String |  |  |
-| Service Endpoint a| String |  |  |
-| Disable session invalidation a| Boolean | If set to true then the session is not invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false | false |
-| Allow field truncation support a| Boolean | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned. | false |
-| Use default rule a| Boolean | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false | false |
-| Can Clear Fields by Updating Field value to Null a| Boolean | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false | false |
+| Name |Description
+| Host |Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Port | Port of the proxy. If host is set, then this property must be set and cannot be a negative number.
+
+Type: Number +
+Default Value: None +
+Required: No
+| Username |Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Password |Password used to authenticate against the proxy.
+
+Type: String +
+Default Value: None +
+Required: No
+| Username | Username used to initialize the session.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Password | Password used to authenticate the user.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Security Token | User's security token. It can be omitted if your IP has been whitelisted on Salesforce.
+
+Type: String +
+Default Value: None +
+Required: No
+| Authorization URL | Web service URL responsible for user authentication. This is the URL for the endpoint that is configured to handle SOAP authentication requests.
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/Soap/u/43.0+` +
+Required: No
+| Reconnection a| | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
+
+Type: <<Reconnection>>  +
+Default Value: None +
+Required: No
+| Pooling Profile | Characteristics of the connection pool.
+
+Type: <<PoolingProfile>> +
+Default Value: None +
+Required: No
+| Read Timeout | Specifies the amount of time, in milliseconds, that the consumer  waits for a response before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Connection Timeout | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Assignment Rule Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Client Id | Client ID for partners.
+
+Type: String +
+Default Value: None +
+Required: No
+| Time Object Store | An xref:object-store::index.adoc[Object Store] instance.
+
+Type: ObjectStore +
+Default Value: None +
+Required: No
+| Batch SObject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
+
+Type: Number +
+Default Value: 5 +
+Required: No
+| Session Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Service Endpoint |
+
+Type: String +
+Default Value: None +
+Required: No
+| Disable session invalidation | If set to true then the session is not invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Allow field truncation support | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Use default rule | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Can Clear Fields by Updating Field value to Null | If false, then to clear a field its name must be provided in an update request in the `fieldsToNull` field, otherwise, for clearing a field it can also be simply added to the request with the value `null`. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
 |===
 
 [[sfdc-config_cached-basic]]
@@ -67,31 +180,119 @@ Salesforce Connector version 9.5.1
 
 ==== Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-| Advanced Reconnection Params a| <<AdvancedReconnectionParams>> |  |  |
-| Host a| String | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified. |  |
-| Port a| Number | Port of the proxy. If host is set then this property must be set and cannot be a negative number. |  |
-| Username a| String | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified. |  |
-| Password a| String | Password used to authenticate against the proxy. |  |
-| Username a| String | Username used to initialize the session. |  |x
-| Password a| String | Password used to authenticate the user. |  |x
-| Security Token a| String | User's security token. It can be omitted if your IP has been whitelisted on Salesforce. |  |
-| Authorization URL a| String | Web service URL responsible for user authentication. This is the URL for the endpoint that is configured to handle SOAP authentication requests. | `+https://login.salesforce.com/services/Soap/u/43.0+` |
-| Reconnection a| <<Reconnection>> | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
-| Read Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite. | 0 |
-| Connection Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite. | 0 |
-| Assignment Rule Id a| String |  |  |
-| Client Id a| String | Client ID for partners. |  |
-| Time Object Store a| ObjectStore | An ObjectStore instance. |  |
-| Batch Sobject Max Depth a| Number | Creating a batch creates SObjects using this value for the MAX_DEPTH check. | 5 |
-| Session Id a| String |  |  |
-| Service Endpoint a| String |  |  |
-| Disable session invalidation a| Boolean | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false | false |
-| Allow field truncation support a| Boolean | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned. | false |
-| Use default rule a| Boolean | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false | false |
-| Can Clear Fields by Updating Field value to Null a| Boolean | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false | false |
+| Name | Description
+| Advanced Reconnection Params | 
+
+Type: <<AdvancedReconnectionParams>> +
+Default Value: None +
+Required: No
+| Host | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Port | Port of the proxy. If host is set then this property must be set and cannot be a negative number.
+
+Type: Number +
+Default Value: None +
+Required: No
+| Username | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Password | Password used to authenticate against the proxy.
+
+Type: String +
+Default Value: None +
+Required: No
+| Username | Username used to initialize the session.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Password | Password used to authenticate the user.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Security Token | User's security token. It can be omitted if your IP has been whitelisted in Salesforce.
+
+Type: String +
+Default Value: None +
+Required: No
+| Authorization URL | Web service URL responsible for user authentication. This is the URL for the endpoint that is configured to handle SOAP authentication requests.
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/Soap/u/43.0+` +
+Required: No
+| Reconnection | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
+
+Type: <<Reconnection>>  +
+Default Value: None +
+Required: No
+| Read Timeout | Specifies the amount of time in milliseconds that the consumer waits for a response before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Connection Timeout | Specifies the amount of time in milliseconds that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Assignment Rule Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Client Id | Client ID for partners.
+
+Type: String +
+Default Value: None +
+Required: No
+| Time Object Store | An xref:object-store::index.adoc[Object Store] instance.
+
+Type: ObjectStore +
+Default Value: None +
+Required: No
+| Batch SObject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
+
+Type: Number +
+Default Value: 5 +
+Required: No
+| Session Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Service Endpoint |
+
+Type: String +
+Default Value: None +
+Required: No
+| Disable session invalidation | If set to true, then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Allow field truncation support | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Use default rule | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Can Clear Fields by Updating Field value to Null |If false, then to clear a field its name must be provided in an update request in the `fieldsToNull` field, otherwise, for clearing a field it can also be simply added to the request with the value `null`. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
 |===
 
 [[sfdc-config_cached-oauth-user-pass]]
@@ -99,86 +300,312 @@ Salesforce Connector version 9.5.1
 
 ==== Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-| Advanced Reconnection Params a| <<AdvancedReconnectionParams>> |  |  |
-| Host a| String |  +++Hostname of the proxy. If this property is not set, then a proxy is not  used, otherwise a proxy is used, but a proxy host must be specified.+++ |  |
-| Port a| Number |  +++Port of the proxy. If host is set, then this property must be set and cannot be a negative number.+++ |  |
-| Username a| String |  +++Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.+++ |  |
-| Password a| String |  +++Password used to authenticate against the proxy.+++ |  |
-| Read Timeout a| Number |  +++Specifies the amount of time in milliseconds that the consumer  waits for a response before it times out. Default value is 0, which means infinite.+++ |  +++0+++ |
-| Connection Timeout a| Number |  +++Specifies the amount of time in milliseconds that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.+++ |  +++0+++ |
-| Assignment Rule Id a| String |  |  |
-| Client Id a| String |  +++Client ID for partners+++ |  |
-| Time Object Store a| <<ObjectStore>> |  +++An ObjectStore instance to use.+++ |  |
-| Batch Sobject Max Depth a| Number |  +++Creating a batch creates SObjects using this value for the MAX_DEPTH check.+++ |  +++5+++ |
-| Api Version a| Number |  |  +++43.0+++ |
-| Disable session invalidation a| Boolean |  +++If set to true, then the session is not invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.+++ |  +++false+++ |
-| Allow field truncation support a| Boolean |  +++If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.+++ |  +++false+++ |
-| Use default rule a| Boolean |  +++If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.+++ |  +++false+++ |
-| Can Clear Fields by Updating Field value to Null a| Boolean |  +++If false, then to clear a field, its name must be provided in an update request in the `fieldsToNull` field, otherwise, when clearing a field, it can also be added to the request with the value `null`. Default value is false.+++ |  +++false+++ |
-| Consumer Key a| String |  +++Consumer key for Salesforce connected app.+++ |  | *x*{nbsp}
-| Consumer Secret a| String |  +++Your application's client secret (consumer secret in Remote Access Detail).+++ |  | *x*{nbsp}
-| Username a| String |  +++Username used to initialize the session.+++ |  | *x*{nbsp}
-| Password a| String |  +++Password used to authenticate the user.+++ |  | *x*{nbsp}
-| Security Token a| String |  +++User's security token. It can be omitted if your IP has been whitelisted on Salesforce.+++ |  |
-| Token Endpoint a| String |  +++URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL).+++ |  +++`+https://login.salesforce.com/services/oauth2/token+`+++ |
-| Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.+++ |  |
+| Name |Description
+| Advanced Reconnection Params |
+
+Type: <<AdvancedReconnectionParams>> +
+Default Value: None +
+Required: No
+| Host | Hostname of the proxy. If this property is not set, then a proxy is not  used, otherwise a proxy is used, but a proxy host must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Port | Port of the proxy. If host is set, then this property must be set and cannot be a negative number.
+
+Type: Number +
+Default Value: None +
+Required: No
+| Username | Username used to authenticate against the proxy. If this property is not set, then no authentication is used against the proxy, otherwise this value must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Password | Password used to authenticate against the proxy.
+
+Type: String +
+Default Value: None +
+Required: No
+| Read Timeout | Specifies the amount of time in milliseconds that the consumer waits for a response before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Connection Timeout | Specifies the amount of time in milliseconds that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Assignment Rule Id | Assignment rule ID.
+
+Type: String +
+Default Value: None +
+Required: No
+| Client Id | Client ID for partners.
+
+Type: String +
+Default Value: None +
+Required: No
+| Time Object Store | An xref:object-store::index.adoc[Object Store] instance.
+
+Type: ObjectStore +
+Default Value: None +
+Required: No|
+| Batch SObject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
+
+Type: Number +
+Default Value: 5 +
+Required: No
+| Api Version | Salesforce API version.
+
+Type: Number +
+Default Value: 43.0 +
+Required: No
+| Disable session invalidation | If set to true, then the session is not invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Allow field truncation support | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Use default rule | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Can Clear Fields by Updating Field value to Null | If false, then to clear a field, its name must be provided in an update request in the `fieldsToNull` field, otherwise, when clearing a field, it can also be added to the request with the value `null`. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Consumer Key | Consumer key for a Salesforce connected application.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Consumer Secret | Your application's client secret (consumer secret in Remote Access Detail).
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Username | Username used to initialize the session.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Password | Password used to authenticate the user.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Security Token | User's security token. It can be omitted if your IP has been whitelisted on Salesforce.
+
+Type: String +
+Default Value: None +
+Required: No
+| Token Endpoint |URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL).
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/oauth2/token+` +
+Required: No
+| Reconnection |When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
+
+Type: <<Reconnection>> +
+Default Value: None +
+Required: No
 |===
 
 [[sfdc-config_config-with-oauth]]
 === OAuth v2.0
 
-
 ==== Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-| Host a| String | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified. |  |
-| Port a| Number | Port of the proxy. If host is set then this property must be set and cannot be a negative number. |  |
-| Username a| String | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified. |  |
-| Password a| String | Password used to authenticate against the proxy. |  |
-| Read Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite. | 0 |
-| Connection Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite. | 0 |
-| Assignment Rule Id a| String |  |  |
-| Client Id a| String | Client ID for partners. |  |
-| Time Object Store a| ObjectStore | An ObjectStore instance. |  |
-| Batch Sobject Max Depth a| Number | Creating a batch creates SObjects using this value for the MAX_DEPTH check. | 5 |
-| Api Version a| Number |  | 43.0 |
-| Disable session invalidation a| Boolean | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false | false |
-| Allow field truncation support a| Boolean | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned. | false |
-| Use default rule a| Boolean | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false | false |
-| Can Clear Fields by Updating Field value to Null a| Boolean | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false | false |
-| Display a| Enumeration, one of:
+| Name |Description
+| Host | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified.
 
-** PAGE
-** POPUP
-** TOUCH |  |  |x
-| Immediate a| Enumeration, one of:
+Type: String +
+Default Value: None +
+Required: No
+| Port | Port of the proxy. If host is set then this property must be set and cannot be a negative number.
 
-** TRUE
-** FALSE |  | false |
-| Prompt a| Enumeration, one of:
+Type: Number +
+Default Value: None +
+Required: No
+| Username | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified. 
 
-** LOGIN
-** CONSENT |  | LOGIN |
-| Reconnection a| <<Reconnection>> | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
-| Pooling Profile a| <<PoolingProfile>> | Characteristics of the connection pool. |  |
-| Consumer Key a| String | The OAuth consumerKey as registered with the service provider. |  |x
-| Consumer Secret a| String | The OAuth consumerSecret as registered with the service provider. |  |x
-| Authorization Url a| String | The service provider's authorization endpoint URL. | `+https://login.salesforce.com/services/oauth2/authorize+` |
-| Access Token Url a| String | The service provider's accessToken endpoint URL. | `+https://login.salesforce.com/services/oauth2/token+` |
-| Scopes a| String | The OAuth scopes to be requested during the dance. If not provided, it will default to those in the annotation. |  |
-| Resource Owner Id a| String | The resourceOwnerId which each component should use if it doesn't reference otherwise. |  |
-| Before a| String | The name of a flow to be executed right before starting the OAuth dance. |  |
-| After a| String | The name of a flow to be executed right after an accessToken has been received. |  |
-| Listener Config a| String | A reference to an `+<http:listener-config />+` to be used to create the listener that will catch the access token callback endpoint. |  |x
-| Callback Path a| String | The path of the access token callback endpoint. |  |x
-| Authorize Path a| String | The path of the local HTTP endpoint which triggers the OAuth dance. |  |x
-| External Callback Url a| String | If the callback endpoint is behind a proxy or should be accessed through a non direct URL, use this parameter to tell the OAuth provider the URL it should use to access the callback. |  |
-| Object Store a| String | A reference to the object store that should be used to store each resource owner id's data. If not specified, the runtime automatically provisions the default one. |  |
+Type: String +
+Default Value: None +
+Required: No
+| Password | Password used to authenticate against the proxy.
+
+Type: String +
+Default Value: None +
+Required: No
+| Read Timeout | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Connection Timeout | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Assignment Rule Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Client Id | Client ID for partners.
+
+Type: String +
+Default Value: None +
+Required: No
+| Time Object Store | An xref:object-store::index.adoc[Object Store] instance.
+
+Type: ObjectStore +
+Default Value: None +
+Required: No
+| Batch SObject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
+
+Type: Number +
+Default Value: 5 +
+Required: No
+| Api Version | Salesforce API version.
+
+Type: Number +
+Default Value: 43.0 +
+Required: No
+| Disable session invalidation | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Allow field truncation support | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Use default rule | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Can Clear Fields by Updating Field value to Null | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Display | 
+
+Type: Enumeration, one of:
+
+* PAGE
+* POPUP
+* TOUCH
+
+Default: None +
+Required: Yes
+| Immediate | 
+
+Type: Enumeration, one of:
+
+* TRUE
+* FALSE
+
+Default: false +
+Required: No
+| Prompt | 
+
+Type: Enumeration, one of:
+
+* LOGIN
+* CONSENT
+
+Default: LOGIN +
+Required: No
+| Reconnection | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
+
+Type: <<Reconnection>>  +
+Default Value: None +
+Required: No
+| Pooling Profile | Characteristics of the connection pool.
+
+Type: <<PoolingProfile>> +
+Default Value: None +
+Required: No
+| Consumer Key | The OAuth consumerKey as registered with the service provider.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Consumer Secret | The OAuth consumerSecret as registered with the service provider.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Authorization Url | The service provider's authorization endpoint URL.
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/oauth2/authorize+` +
+Required: No
+| Access Token Url | The service provider's accessToken endpoint URL.
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/oauth2/token+` +
+Required: No
+| Scopes | The OAuth scopes to be requested during the OAuth dance. If not provided, this defaults to the scopes in the annotation.
+
+Type: String +
+Default Value: None +
+Required: No
+| Resource Owner Id | The resourceOwnerId which each component should use if it doesn't reference otherwise.
+
+Type: String +
+Default Value: None +
+Required: No
+| Before | The name of a flow to be executed right before starting the OAuth dance.
+
+Type: String +
+Default Value: None +
+Required: No
+| After | The name of a flow to be executed right after an accessToken has been received.
+
+Type: String +
+Default Value: None +
+Required: No
+| Listener Config | A reference to an `+<http:listener-config />+` to be used to create the listener that catches the access token callback endpoint.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Callback Path | The path of the access token callback endpoint.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Authorize Path | The path of the local HTTP endpoint which triggers the OAuth dance.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| External Callback Url | If the callback endpoint is behind a proxy or should be accessed through a non direct URL, use this parameter to tell the OAuth provider the URL it should use to access the callback.
+
+Type: String +
+Default Value: None +
+Required: No
+| Object Store | A reference to the object store that should be used to store each resource owner IDs data. If not specified, the runtime automatically provisions the default one.
+
+Type: String +
+Default Value: None +
+Required: No
 |===
 
 [[sfdc-config_oauth-jwt]]
@@ -186,31 +613,119 @@ Salesforce Connector version 9.5.1
 
 ==== Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-| Host a| String | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified. |  |
-| Port a| Number | Port of the proxy. If host is set then this property must be set and cannot be a negative number. |  |
-| Username a| String | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified. |  |
-| Password a| String | Password used to authenticate against the proxy. |  |
-| Read Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite. | 0 |
-| Connection Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite. | 0 |
-| Assignment Rule Id a| String |  |  |
-| Client Id a| String | Client ID for partners. |  |
-| Time Object Store a| ObjectStore | An ObjectStore instance. |  |
-| Batch Sobject Max Depth a| Number | Creating a batch creates SObjects using this value for the MAX_DEPTH check. | 5 |
-| Api Version a| Number |  | 43.0 |
-| Disable session invalidation a| Boolean | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false | false |
-| Allow field truncation support a| Boolean | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned. | false |
-| Use default rule a| Boolean | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false | false |
-| Can Clear Fields by Updating Field value to Null a| Boolean | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false | false |
-| Consumer Key a| String | Consumer key for Salesforce connected app. |  |x
-| Key Store a| String | Path to key store used to sign data during authentication. |  |x
-| Store Password a| String | Password of key store. |  |x
-| Principal a| String | Username of desired Salesforce user to take action on behalf of. |  |x
-| Token Endpoint a| String | URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or, if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL). | `+https://login.salesforce.com/services/oauth2/token+` |
-| Reconnection a| <<Reconnection>> | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
-| Pooling Profile a| <<PoolingProfile>> | Characteristics of the connection pool. |  |
+| Name |Description
+| Host | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Port | Port of the proxy. If host is set then this property must be set and cannot be a negative number.
+
+Type: Number +
+Default Value: None +
+Required: No
+| Username | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Password | Password used to authenticate against the proxy.
+
+Type: String +
+Default Value: None +
+Required: No
+| Read Timeout Specifies the amount of time in milliseconds that the consumer waits for a response before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Connection Timeout | Specifies the amount of time in milliseconds that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Assignment Rule Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Client Id | Client ID for partners.
+
+Type: String +
+Default Value: None +
+Required: No
+| Time Object Store | An xref:object-store::index.adoc[Object Store] instance.
+
+Type: ObjectStore +
+Default Value: None +
+Required: No
+| Batch SObject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
+
+Type: Number +
+Default Value: 5 +
+Required: No
+| Api Version | Salesforce API version.
+
+Type: Number +
+Default Value: 43.0 +
+Required: No
+| Disable session invalidation | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Allow field truncation support | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Use default rule | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Can Clear Fields by Updating Field value to Null | If false, then to clear a field, its name must be provided in an update request in the `fieldsToNull` field, otherwise, for clearing a field it can also be simply added to the request with the value `null`. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Consumer Key | Consumer key for Salesforce connected app.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Key Store | Path to key store used to sign data during authentication.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Store Password | Password of key store.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Principal | Username of desired Salesforce user to take action on behalf of.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Token Endpoint | URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or, if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL).
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/oauth2/token+`  +
+Required: No
+| Reconnection | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
+
+Type: <<Reconnection>> +
+Default Value: None +
+Required: No
+| Pooling Profile | Characteristics of the connection pool.
+
+Type: <<PoolingProfile>> +
+Default Value: None +
+Required: No
 |===
 
 [[sfdc-config_oauth-saml]]
@@ -218,31 +733,119 @@ Salesforce Connector version 9.5.1
 
 ==== Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-| Host a| String | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified. |  |
-| Port a| Number | Port of the proxy. If host is set then this property must be set and cannot be a negative number. |  |
-| Username a| String | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified. |  |
-| Password a| String | Password used to authenticate against the proxy. |  |
-| Read Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite. | 0 |
-| Connection Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite. | 0 |
-| Assignment Rule Id a| String |  |  |
-| Client Id a| String | Client ID for partners. |  |
-| Time Object Store a| ObjectStore | An ObjectStore instance. |  |
-| Batch Sobject Max Depth a| Number | Creating a batch creates SObjects using this value for the MAX_DEPTH check. | 5 |
-| Api Version a| Number |  | 43.0 |
-| Disable session invalidation a| Boolean | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false | false |
-| Allow field truncation support a| Boolean | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned. | false |
-| Use default rule a| Boolean | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false | false |
-| Can Clear Fields by Updating Field value to Null a| Boolean | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false | false |
-| Consumer Key a| String | Consumer key for Salesforce connected app. |  |x
-| Key Store a| String | Path to key store used to sign data during authentication. |  |x
-| Store Password a| String | Password of key store. |  |x
-| Principal a| String | Username of desired Salesforce user to take action on behalf of. |  |x
-| Token Endpoint a| String | URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or, if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL). | `+https://login.salesforce.com/services/oauth2/token+` |
-| Reconnection a| <<Reconnection>> | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
-| Pooling Profile a| <<PoolingProfile>> | Characteristics of the connection pool. |  |
+| Name |Description
+| Host | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Port | Port of the proxy. If host is set then this property must be set and cannot be a negative number. 
+
+Type: Number +
+Default Value: None +
+Required: No
+| Username | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Password | Password used to authenticate against the proxy.
+
+Type: String +
+Default Value: None +
+Required: No
+| Read Timeout | Specifies the amount of time in milliseconds that the consumer waits for a response before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Connection Timeout | Specifies the amount of time in milliseconds that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Assignment Rule Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Client Id | Client ID for partners.
+
+Type: String +
+Default Value: None +
+Required: No
+| Time Object Store | An xref:object-store::index.adoc[Object Store] instance.
+
+Type: ObjectStore +
+Default Value: None +
+Required: No
+| Batch Sobject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
+
+Type: Number +
+Default Value: 5 +
+Required: No
+| Api Version | Salesforce API version.
+
+Type: Number +
+Default Value: 43.0 +
+Required: No
+| Disable session invalidation | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Allow field truncation support | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Use default rule | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Can Clear Fields by Updating Field value to Null | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Consumer Key | Consumer key for Salesforce connected app.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Key Store | Path to key store used to sign data during authentication.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Store Password | Password of key store.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Principal | Username of desired Salesforce user to take action on behalf of.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Token Endpoint | URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or, if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL). 
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/oauth2/token+`  +
+Required: No
+| Reconnection | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
+
+Type: <<Reconnection>> +
+Default Value: None +
+Required: No
+| Pooling Profile | Characteristics of the connection pool.
+
+Type: <<PoolingProfile>> +
+Default Value: None +
+Required: No
 |===
 
 [[sfdc-config_oauth-user-pass]]
@@ -250,35 +853,127 @@ Salesforce Connector version 9.5.1
 
 ==== Parameters
 
-[%header%autowidth.spread]
+[%header,cols="30a,70a"]
 |===
-| Name | Type | Description | Default Value | Required
-| Host a| String | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified. |  |
-| Port a| Number | Port of the proxy. If host is set then this property must be set and cannot be a negative number. |  |
-| Username a| String | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified. |  |
-| Password a| String | Password used to authenticate against the proxy. |  |
-| Read Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite. | 0 |
-| Connection Timeout a| Number | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite. | 0 |
-| Assignment Rule Id a| String |  |  |
-| Client Id a| String | Client ID for partners. |  |
-| Time Object Store a| ObjectStore | An ObjectStore instance. |  |
-| Batch Sobject Max Depth a| Number | Creating a batch creates SObjects using this value for the MAX_DEPTH check. | 5 |
-| Api Version a| Number |  | 43.0 |
-| Disable session invalidation a| Boolean | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false | false |
-| Allow field truncation support a| Boolean | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned. | false |
-| Use default rule a| Boolean | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false | false |
-| Can Clear Fields by Updating Field value to Null a| Boolean | If false, then to clear a field its name must be provided in an update request in the 'fieldsToNull' field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false | false |
-| Consumer Key a| String | Consumer key for Salesforce connected app. |  |x
-| Consumer Secret a| String | Your application's client secret (consumer secret in Remote Access Detail). |  |x
-| Username a| String | Username used to initialize the session. |  |x
-| Password a| String | Password used to authenticate the user. |  |x
-| Security Token a| String | User's security token. It can be omitted if your IP has been whitelisted on Salesforce. |  |
-| Token Endpoint a| String | URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or, if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL). | `+https://login.salesforce.com/services/oauth2/token+` |
-| Reconnection a| <<Reconnection>> | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
-| Pooling Profile a| <<PoolingProfile>> | Characteristics of the connection pool. |  |
+| Name |Description
+| Host | Hostname of the proxy. If this property is not set, then no proxy is used, otherwise a proxy is used, but a proxy host must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Port | Port of the proxy. If host is set then this property must be set and cannot be a negative number.
+
+Type: Number +
+Default Value: None +
+Required: No
+| Username | Username used to authenticate against the proxy. If this property is not set then no authentication is going to be used against the proxy, otherwise this value must be specified.
+
+Type: String +
+Default Value: None +
+Required: No
+| Password | Password used to authenticate against the proxy.
+
+Type: String +
+Default Value: None +
+Required: No
+| Read Timeout | Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Connection Timeout | Specifies the amount of time, in milliseconds, that the consumer attempts to establish a connection before it times out. Default value is 0, which means infinite.
+
+Type: Number +
+Default Value: 0 +
+Required: No
+| Assignment Rule Id |
+
+Type: String +
+Default Value: None +
+Required: No
+| Client Id | Client ID for partners.
+
+Type: String +
+Default Value: None +
+Required: No
+| Time Object Store | An xref:object-store::index.adoc[Object Store] instance.
+
+Type: ObjectStore +
+Default Value: None +
+Required: No
+| Batch SObject Max Depth | Creating a batch creates SObjects using this value for the MAX_DEPTH check.
+
+Type: Number +
+Default Value: 5 +
+Required: No
+| Api Version | Salesforce API version.
+
+Type: Number +
+Default Value: 43.0 +
+Required: No
+| Disable session invalidation | If set to true then the session will not be invalidated when the connection pool deems the connection is no longer needed. This could be useful if you use the same username from several applications and get the same session from Salesforce. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Allow field truncation support | If true, truncates field values that are too long, which is the behavior in API versions 14.0 and earlier. Default is false: no change in behavior. If a string or text area value is too large, the operation fails and the fault code STRING_TOO_LONG is returned.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Use default rule | If true, the default (active) assignment rule for a Case or Lead is used. If specified, do not specify an assignmentRuleId. If true for an Account, all territory assignment rules are applied, and if false, no territory assignment rules are applied. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Can Clear Fields by Updating Field value to Null | If false, then to clear a field its name must be provided in an update request in the `fieldsToNull` field, otherwise, for clearing a field it can also be simply added to the request with the value 'null'. Default value is false.
+
+Type: Boolean +
+Default Value: false +
+Required: No
+| Consumer Key | Consumer key for a Salesforce connected application.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Consumer Secret | Your application's client secret (consumer secret in Remote Access Detail).
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Username | Username used to initialize the session.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Password | Password used to authenticate the user.
+
+Type: String +
+Default Value: None +
+Required: Yes
+| Security Token | User's security token. It can be omitted if your IP has been whitelisted on Salesforce.
+
+Type: String +
+Default Value: None +
+Required: No
+| Token Endpoint | URL pointing to the server responsible for providing the authentication token. According to Salesforce it should be `+https://login.salesforce.com/services/oauth2/token+`, or, if implementing for a community, `+https://acme.force.com/customers/services/oauth2/token+` (where acme.force.com/customers is your community URL).
+
+Type: String +
+Default Value: `+https://login.salesforce.com/services/oauth2/token+`  +
+Required: No
+| Reconnection | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy.
+
+Type: <<Reconnection>> +
+Default Value: None +
+Required: No
+| Pooling Profile | Characteristics of the connection pool.
+
+Type: <<PoolingProfile>> +
+Default Value: None +
+Required: No
 |===
 
-== Associated Operations
+== Supported Operations
 
 * <<abortJob>>
 * <<abortJobV2>>
@@ -386,9 +1081,7 @@ Salesforce Connector version 9.5.1
 
 `<salesforce:abort-job>`
 
-
 Aborts an open Job given its ID. 
-
 
 === Parameters
 
@@ -472,9 +1165,7 @@ Aborts an ongoing Bulk API V2 Job. This call uses the Bulk API v2.
 
 `<salesforce:batch-info>`
 
-
-Access latest BatchInfo of a submitted BatchInfo. Allows tracking of the execution status. 
-
+Access latest BatchInfo of a submitted BatchInfo. Allows tracking of the execution status.
 
 === Parameters
 
@@ -523,9 +1214,7 @@ Access latest BatchInfo of a submitted BatchInfo. Allows tracking of the executi
 
 `<salesforce:batch-info-list>`
 
-
 Get information about all batches in a job. 
-
 
 === Parameters
 
@@ -575,7 +1264,7 @@ Get information about all batches in a job.
 `<salesforce:batch-result>`
 
 
-Access com. sforce. async. BatchResult of a submitted BatchInfo. 
+Access com.sforce.async.BatchResult of a submitted BatchInfo. 
 
 
 === Parameters
@@ -584,7 +1273,7 @@ Access com. sforce. async. BatchResult of a submitted BatchInfo.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | |x
-| Batch To Retrieve a| <<BatchInfo>> | The com. sforce. async. BatchInfo being monitored. | `#[payload]` |
+| Batch To Retrieve a| <<BatchInfo>> | The com.sforce.async.BatchInfo being monitored. | `#[payload]` |
 | Content type a| Enumeration, one of:
 
 ** XML
@@ -635,7 +1324,7 @@ Access com. sforce. async. BatchResult of a submitted BatchInfo.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | |x
-| Batch To Retrieve a| <<BatchInfo>> | The com. sforce. async. BatchInfo being monitored. | `#[payload]` |
+| Batch To Retrieve a| <<BatchInfo>> | The com.sforce.async.BatchInfo being monitored. | `#[payload]` |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
 * non-repeatable-stream | Configure if repeatable streams should be used and their behavior. |  |
@@ -682,7 +1371,7 @@ Access latest BatchInfo of a submitted BatchInfo. Allows tracking of the executi
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | |x
-| Batch info a| <<BatchInfo>> | The org. mule. extension. salesforce. api. bulk. BatchInfo being monitored. | `#[payload]` |
+| Batch info a| <<BatchInfo>> | The org.mule.extension.salesforce.api.bulk.BatchInfo being monitored. | `#[payload]` |
 | Content type a| Enumeration, one of:
 
 ** XML
@@ -776,7 +1465,7 @@ Access com. sforce. async. BatchResult of a submitted BatchInfo.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | |x
-| Batch To Retrieve a| <<BatchInfo>> | The com. sforce. async. BatchInfo being monitored. | `#[payload]` |
+| Batch To Retrieve a| <<BatchInfo>> | The com.sforce.async.BatchInfo being monitored. | `#[payload]` |
 | Target Variable a| String | The name of a variable in which the output of the operation is placed. |  |
 | Target Value a| String | An expression that will be evaluated against the operation's output and the outcome of that expression is stored in the target variable. | `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
@@ -819,7 +1508,7 @@ Access com. sforce. async. BatchResult of a submitted BatchInfo.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | |x
-| Batch To Retrieve a| <<BatchInfo>> | The com. sforce. async. BatchInfo being monitored. | `#[payload]` |
+| Batch To Retrieve a| <<BatchInfo>> | The com.sforce.async.BatchInfo being monitored. | `#[payload]` |
 | Headers a| Object |  |  |
 | Target Variable a| String | The name of a variable in which the output of the operation is placed. |  |
 | Target Value a| String | An expression that will be evaluated against the operation's output and the outcome of that expression is stored in the target variable. | `#[payload]` |
@@ -942,7 +1631,7 @@ Converts a Lead into an Account, Contact, or (optionally) an Opportunity.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | |x
-| Lead Convert Request a| <<LeadConvertRequest>> | information needed for lead convertion. | `#[payload]` |
+| Lead Convert Request a| <<LeadConvertRequest>> | Information needed for lead conversion. | `#[payload]` |
 | Headers a| Object |  |  |
 | Target Variable a| String | The name of a variable in which the output of the operation is placed. |  |
 | Target Value a| String | An expression that will be evaluated against the operation's output and the outcome of that expression is stored in the target variable. | `#[payload]` |
@@ -1988,7 +2677,7 @@ Performs rule-based searches for duplicate records. The input is an array of sal
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | |x
-| Type a| String | Type of sobjects to find duplicates for. |  |x
+| Type a| String | Type of SObjects to find duplicates for. |  |x
 | Criteria a| Array of Object | List of SObject used as a criterion when searching for duplicates. | `#[payload]` |
 | Headers a| Object |  |  |
 | Target Variable a| String | The name of a variable in which the output of the operation is placed. |  |
@@ -4631,8 +5320,8 @@ Subscribe to a topic. First the topic must be published and after that a subscri
 |===
 | Field | Type | Description | Default Value | Required
 | Initial Buffer Size a| Number | This is the amount of memory that will be allocated to consume the stream and provide random access to it. If the stream contains more data than can be fit into this buffer, then the buffer expands according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. |  | 
-| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower will mean that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error will be raised when the buffer gets full. |  | 
-| Max Buffer Size a| Number | This is the maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error will be raised. A value lower or equal to zero means no limit. |  | 
+| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised when the buffer gets full. |  | 
+| Max Buffer Size a| Number | This is the maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower or equal to zero means no limit. |  | 
 | Buffer Unit a| Enumeration, one of:
 
 ** BYTE
@@ -4647,7 +5336,7 @@ Subscribe to a topic. First the topic must be published and after that a subscri
 [%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Max In Memory Size a| Number | Defines the maximum memory that the stream should use to keep data in memory. If more than that is consumed then it will start to buffer the content on disk. |  | 
+| Max In Memory Size a| Number | Defines the maximum memory that the stream should use to keep data in memory. If more than that is consumed then it starts to buffer the content on disk. |  | 
 | Buffer Unit a| Enumeration, one of:
 
 ** BYTE
@@ -4918,12 +5607,14 @@ Subscribe to a topic. First the topic must be published and after that a subscri
 [%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Contact Id a| String | ID of the Contact into which the lead will be merged (this contact must be associated with the specified accountId, and an accountId must be specified). Required only when
- updating an existing contact. IMPORTANT if you are converting a lead into a person account, do not specify the contactId or an error will result. Specify only the accountId
- of the person account. If no contactID is specified, then the API creates a new contact that is implicitly associated with the Account. To create a new contact, the client
- application must be logged in with sufficient access rights. To merge a lead into an existing contact, the client application must be logged in with read/write access to the
- specified contact. The contact name and other existing data are not overwritten (unless overwriteLeadSource is set to true, in which case only the LeadSource field is
- overwritten). For information on IDs, see ID Field Type. |  | 
+| Contact Id a| String | ID of the Contact into which the lead will be merged (this contact must be associated with the specified accountId, and an accountId must be specified). Required only when updating an existing contact. 
+
+IMPORTANT: If you are converting a lead into a person account, do not specify the contactId or an error will result. Specify only the accountId of the person account. If no contactID is specified, then the API creates a new contact that is implicitly associated with the Account. 
+
+To create a new contact, the client
+application must be logged in with sufficient access rights. To merge a lead into an existing contact, the client application must be logged in with read/write access to the
+specified contact. The contact name and other existing data are not overwritten (unless overwriteLeadSource is set to true, in which case only the LeadSource field is
+overwritten). For information on IDs, see ID Field Type. |  | 
 | Account Id a| String | ID of the Account into which the lead will be merged. Required only when updating an existing account, including person accounts. If no accountID is specified, then the API
  creates a new account. To create a new account, the client application must be logged in with sufficient access rights. To merge a lead into an existing account, the client
  application must be logged in with read/write access to the specified account. The account name and other existing data are not overwritten. For information on IDs, see ID
@@ -5401,9 +6092,9 @@ Subscribe to a topic. First the topic must be published and after that a subscri
 [%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Initial Buffer Size a| Number | This is the amount of instances that will be initially be allowed to be kept in memory to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then it will be expanded according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. Default value is 100 instances. |  | 
-| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower will mean that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error will be raised when the buffer gets full. Default value is 100 instances. |  | 
-| Max Buffer Size a| Number | This is the maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error will be raised. A value lower or equal to zero means no limit. |  | 
+| Initial Buffer Size a| Number | This is the amount of instances that will be initially be allowed to be kept in memory to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then it expands according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. Default value is 100 instances. |  | 
+| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised when the buffer gets full. Default value is 100 instances. |  | 
+| Max Buffer Size a| Number | This is the maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower or equal to zero means no limit. |  | 
 |===
 
 [[repeatable-file-store-iterable]]
@@ -5412,7 +6103,7 @@ Subscribe to a topic. First the topic must be published and after that a subscri
 [%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Max In Memory Size a| Number | This is the maximum amount of instances that will be kept in memory. If more than that is required, then it will start to buffer the content on disk. |  | 
+| Max In Memory Size a| Number | This is the maximum amount of instances to keep in memory. If more than that is required, then it will start to buffer the content on disk. |  | 
 | Buffer Unit a| Enumeration, one of:
 
 ** BYTE


### PR DESCRIPTION
Reformatted table because required fields couldn't be seen in the rightmost column.