### PR TITLE
IBM MQ Reference: Block syntax fix

### DIFF
--- a/modules/ROOT/pages/ibm/ibm-mq-xml-ref.adoc
+++ b/modules/ROOT/pages/ibm/ibm-mq-xml-ref.adoc
@@ -579,18 +579,18 @@ Allows the user to perform a session recover when the AckMode#MANUAL mode is ele
 ** DAYS | A time unit that qualifies the maxIdleTime attribute.|  |
 |===
 
-[[IBM MQ Attributes]]
+[[IBM-MQ-Attributes]]
 == IBM MQ Attributes
 
 [%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Properties a| <<JMS Message Properties>> |  |  |
+| Properties a| <<JMS-Message-Properties,JMS Message Properties>> |  |  |
 | Headers a| Any |  |  | x
 | Ack Id a| String |  |  |
 |===
 
-[[JMS Message Properties]]
+[[JMS-Message-Properties]]
 == JMS Message Properties
 
 [%header%autowidth.spread]
@@ -599,10 +599,10 @@ Allows the user to perform a session recover when the AckMode#MANUAL mode is ele
 | All a| Any |  |  | x
 | User Properties a| Any |  |  | x
 | Jms Properties a| Any |  |  | x
-| Jmsx Properties a| <<JMSX Properties>> |  |  |
+| Jmsx Properties a| <<JMSX-Properties,JMSX Properties>> |  |  |
 |===
 
-[[JMSX Properties]]
+[[JMSX-Properties]]
 == JMSX Properties
 
 [%header%autowidth.spread]


### PR DESCRIPTION
for IBM MQ Attributes, JMS Message Properties, and JMSX properties