### PR TITLE
Added detail about allowed input to Archive op

### DIFF
--- a/modules/ROOT/pages/compression/compression-module.adoc
+++ b/modules/ROOT/pages/compression/compression-module.adoc
@@ -197,7 +197,7 @@ Note that the slash (`/`) in the name of an entry (for example,
 `details/result_001.pdf`) indicates directory separation, so all names will be
 introspected to create directories inside the archive.
 
-Note: If you create the input to the Archive operation using a DataWeave expression, the DataWeave expression must output an Object, which is used to build the Java Map object. In order for the entire object to be added to the archive, every key must be unique. 
+NOTE: If you create the input to the Archive operation using a DataWeave expression, the DataWeave expression must output an Object, which is used to build the Java Map object. For the entire object to be added to the archive, every key must be unique. 
 
 ==== Archive Errors
 

--- a/modules/ROOT/pages/compression/compression-module.adoc
+++ b/modules/ROOT/pages/compression/compression-module.adoc
@@ -155,7 +155,7 @@ should be compressed with the `zip` format.
 
 This operation receives a Map that identifies the entries to be compressed and
 their values. Each entry passed to this operation is placed inside the
-compressed archive bearing the name you provide.
+compressed archive bearing the name you provide. 
 
 [source, xml, linenums]
 ----
@@ -196,6 +196,8 @@ directory called `details`:
 Note that the slash (`/`) in the name of an entry (for example,
 `details/result_001.pdf`) indicates directory separation, so all names will be
 introspected to create directories inside the archive.
+
+Note: If you create the input to the Archive operation using a DataWeave expression, the DataWeave expression must output an Object, which is used to build the Java Map object. In order for the entire object to be added to the archive, every key must be unique. 
 
 ==== Archive Errors
 


### PR DESCRIPTION
The Archive op uses an Object that can be converted to a Java Map object.