### PR TITLE
Updated names of Amazon Connectors

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@ For Mule 3 connectors, see xref:3.9@mule-runtime::anypoint-connectors.adoc[Anypo
 
 * xref:salesforce/salesforce-connector.adoc[Salesforce], 
 xref:sftp/sftp-connector.adoc[SFTP], 
-xref:amazon/amazon-s3-connector.adoc[S3], 
+xref:amazon/amazon-s3-connector.adoc[Amazon S3], 
 xref:sap/sap-connector.adoc[SAP], 
 xref:ftp/ftp-connector.adoc[FTP], 
 xref:amazon/amazon-sqs-connector.adoc[Amazon SQS], 
@@ -31,11 +31,11 @@ xref:ms-dynamics/ms-service-bus-connector.adoc[Microsoft Service Bus]
 == Mule 4 Connectors
 
 * xref:amazon/amazon-dynamodb-connector.adoc[Amazon DynamoDB],
-xref:amazon/amazon-ec2-connector.adoc[EC2],
-xref:amazon/amazon-rds-connector.adoc[RDS],
-xref:amazon/amazon-s3-connector.adoc[S3],
-xref:amazon/amazon-sns-connector.adoc[SNS],
-xref:amazon/amazon-sqs-connector.adoc[SQS]
+xref:amazon/amazon-ec2-connector.adoc[Amazon EC2],
+xref:amazon/amazon-rds-connector.adoc[Amazon RDS],
+xref:amazon/amazon-s3-connector.adoc[Amazon S3],
+xref:amazon/amazon-sns-connector.adoc[Amazon SNS],
+xref:amazon/amazon-sqs-connector.adoc[Amazon SQS]
 * xref:amqp/amqp-connector.adoc[AMQP]
 * xref:anypoint-mq/anypoint-mq-connector.adoc[Anypoint MQ]
 * xref:bmc/bmc-remedy-connector.adoc[BMC Remedy]
@@ -59,7 +59,7 @@ xref:hl7/hl7-mllp-connector.adoc[HL7 MLLP]
 * xref:jms/jms-connector.adoc[JMS]
 * xref:kafka/kafka-connector.adoc[Kafka]
 * xref:ldap/ldap-connector.adoc[LDAP]
-* xref:marketo/marketo-connector.adoc[Marketo]
+* xref:marketo/marketo-connector.adoc[Adobe Marketo]
 * xref:microsoft/microsoft-dotnet-connector.adoc[Microsoft .NET],
 xref:microsoft/microsoft-dynamics-365-connector.adoc[Microsoft Dynamics 365],
 xref:microsoft/microsoft-365-ops-connector.adoc[Microsoft Dynamics 365 Operations],


### PR DESCRIPTION
Updated names of Amazon Connectors to include the word "Amazon" in the name. Example - Amazon S3