### PR TITLE
MongoDB 5.3.1 - updated reference

### DIFF
--- a/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
+++ b/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
@@ -3,6 +3,10 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
+Support Category: Select
+
+MongoDB Connector v5.3
+
 +++
 MongoDB is an open source, high-performance, schema-free, document-oriented database that manages collections of BSON documents.
 +++

--- a/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
+++ b/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
@@ -2191,7 +2191,7 @@ Update documents using one or more mongo function(s). If query is not specified,
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  +++The name of the collection to update+++ |  | x
 | Find Query a| Binary |  +++The String query document used to detect the element to update+++ |  |
-| Functions a| Binary |  +++The String of functions used to execute the update. e.g. &lt;$set,{"key":123}&gt;+++ |  | x
+| Functions a| Binary a|  The String of functions used to execute the update. For example, `<$set,{"key":123}>` |  | x
 | Upsert a| Boolean |  +++Whether the database should create the element if it does not exist+++ |  +++false+++ |
 | Multiple Update a| Boolean |  +++If all or just the first document matching the query will be updated+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>

--- a/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
+++ b/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
@@ -45,9 +45,9 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 | Max Wait Time a| Number |  +++The max wait time for a blocking thread for a connection from the pool in ms.+++ |  +++120000+++ |
 | Connect Timeout a| Number |  +++The connection timeout in milliseconds; this is for establishing the socket connections (open). 0 is default and infinite.+++ |  +++30000+++ |
 | Socket Timeout a| Number |  +++The socket timeout. 0 is default and infinite.+++ |  +++0+++ |
-| Username a| String |  |  ++++++ |
+| Username a| String | +++the username to use for authentication.+++  |  ++++++ |
 | Password a| String |  +++the password to use for authentication. If the password is null or whitespaces only, the connector won't use authentication and username must be empty too.+++ |  |
-| Database a| String |  |  | x
+| Database a| String | +++Name of the database+++ |  | x
 | SSL a| Boolean |  +++This is for enabling an SSL connection. It is disabled by default.+++ |  +++false+++ |
 | Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy+++ |  |
 |===
@@ -2190,7 +2190,7 @@ Update documents using one or more mongo function(s). If query is not specified,
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  +++the name of the collection to update+++ |  | x
 | Find Query a| Binary |  +++the String query document used to detect the element to update+++ |  |
-| Functions a| Binary |  +++the String of functions used to execute the update. e.g. <$set,{"key":123}>+++ |  | x
+| Functions a| Binary |  +++the String of functions used to execute the update. e.g. &lt;$set,{"key":123}&gt;+++ |  | x
 | Upsert a| Boolean |  +++whether the database should create the element if it does not exist+++ |  +++false+++ |
 | Multiple Update a| Boolean |  +++if all or just the first document matching the query will be updated+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
@@ -2338,17 +2338,17 @@ Update documents using one or more mongo function(s). If query is not specified,
 [cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
 |===
 | Field | Type | Description | Default Value | Required
-| Value a| <<ObjectId>> |  |  |
+| Value a| <<MongoIdObject>> |  |  |
 |===
 
-[[ObjectId]]
-=== Object Id
+[[MongoIdObject]]
+=== Mongo Id Object
 
 [cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
 |===
 | Field | Type | Description | Default Value | Required
 | Counter a| Number |  |  |
-| Date a| Date |  |  |
+| Date a| String |  |  |
 | Machine Identifier a| Number |  |  |
 | Process Identifier a| Number |  |  |
 | Time a| Number |  |  |

--- a/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
+++ b/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
@@ -28,7 +28,7 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 * <<config_connection-string, Connection String>>
  | The connection types that can be provided to this configuration. | | x
 | Expiration Policy a| <<ExpirationPolicy>> |  +++Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. The runtime actually purges the instances when it sees fit.+++ |  |
-| Enable Metadata a| Boolean |  +++collectionMetadataSamples: Stores templates to build metadata based on Document parameters union Key (String): Collection Name. List<String>: List of ObjectIDs Documents in specific collection.+++ |  +++true+++ |
+| Enable Metadata a| Boolean |  +++collectionMetadataSamples: Stores templates to build metadata based on the document parameters `union Key (String): Collection Name`. `List<String>:` List of ObjectIDs documents in a collection.+++ |  +++true+++ |
 | Collection Metadata samples a| Object |  |  |
 |===
 
@@ -42,7 +42,7 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
 |===
 | Name | Type | Description | Default Value | Required
-| Servers (host:port) a| String |  +++A list of MongoDB instance, with the format <code>host:port</code>, separated by commas. Example: `+127.0.0.1:27017+`, `+192.168.1.2:27017+` +++ |  +++localhost:27017+++ |
+| Servers (host:port) a| String a|  A list of MongoDB instance, with the format `host:port<`, separated by commas. Example: `+127.0.0.1:27017+`, `+192.168.1.2:27017+`  |  `localhost:27017` |
 | Connections Per Host a| Number |  +++The number of connections allowed per host (the pool size, per host)+++ |  +++100+++ |
 | Threads Allowed To Block For Connection Multiplier a| Number |  +++Multiplier for connectionsPerHost for # of threads that can block.+++ |  +++5+++ |
 | Max Wait Time a| Number |  +++The max wait time for a blocking thread for a connection from the pool in ms.+++ |  +++120000+++ |
@@ -51,9 +51,10 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 | Username a| String | +++The username to use for authentication.+++  |  ++++++ |
 | Password a| String |  +++The password to use for authentication. If the password is null or whitespaces only, the connector won't use authentication and username must be empty too.+++ |  |
 | Database a| String | +++Name of the database+++ |  | x
-| SSL a| Boolean |  +++This is for enabling an SSL connection. It is disabled by default.+++ |  +++false+++ |
+| SSL a| Boolean |  +++Enables an SSL connection. It is disabled by default.+++ |  +++false+++ |
 | Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy+++ |  |
 |===
+
 [[config_connection-string]]
 ===== Connection String
 

--- a/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
+++ b/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
@@ -23,7 +23,7 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 | Connection a| * <<config_connection, Connection>>
 * <<config_connection-string, Connection String>>
  | The connection types that can be provided to this configuration. | | x
-| Expiration Policy a| <<ExpirationPolicy>> |  +++Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. The runtime will actually purge the instances when it sees it fit.+++ |  |
+| Expiration Policy a| <<ExpirationPolicy>> |  +++Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. The runtime actually purges the instances when it sees fit.+++ |  |
 | Enable Metadata a| Boolean |  +++collectionMetadataSamples: Stores templates to build metadata based on Document parameters union Key (String): Collection Name. List<String>: List of ObjectIDs Documents in specific collection.+++ |  +++true+++ |
 | Collection Metadata samples a| Object |  |  |
 |===
@@ -38,15 +38,14 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
 |===
 | Name | Type | Description | Default Value | Required
-| Servers (host:port) a| String |  +++A list of MongoDB instance, with the format <code>host:port</code>, separated by commas. <p>
- <pre> Example: 127.0.0.1:27017, 192.168.1.2:27017 </pre>+++ |  +++localhost:27017+++ |
+| Servers (host:port) a| String |  +++A list of MongoDB instance, with the format <code>host:port</code>, separated by commas. Example: `+127.0.0.1:27017+`, `+192.168.1.2:27017+` +++ |  +++localhost:27017+++ |
 | Connections Per Host a| Number |  +++The number of connections allowed per host (the pool size, per host)+++ |  +++100+++ |
 | Threads Allowed To Block For Connection Multiplier a| Number |  +++Multiplier for connectionsPerHost for # of threads that can block.+++ |  +++5+++ |
 | Max Wait Time a| Number |  +++The max wait time for a blocking thread for a connection from the pool in ms.+++ |  +++120000+++ |
 | Connect Timeout a| Number |  +++The connection timeout in milliseconds; this is for establishing the socket connections (open). 0 is default and infinite.+++ |  +++30000+++ |
 | Socket Timeout a| Number |  +++The socket timeout. 0 is default and infinite.+++ |  +++0+++ |
-| Username a| String | +++the username to use for authentication.+++  |  ++++++ |
-| Password a| String |  +++the password to use for authentication. If the password is null or whitespaces only, the connector won't use authentication and username must be empty too.+++ |  |
+| Username a| String | +++The username to use for authentication.+++  |  ++++++ |
+| Password a| String |  +++The password to use for authentication. If the password is null or whitespaces only, the connector won't use authentication and username must be empty too.+++ |  |
 | Database a| String | +++Name of the database+++ |  | x
 | SSL a| Boolean |  +++This is for enabling an SSL connection. It is disabled by default.+++ |  +++false+++ |
 | Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy+++ |  |
@@ -189,9 +188,9 @@ Counts the number of documents that match the given query. If no query is passed
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the target collection+++ |  | x
-| Condition Query a| Binary |  +++the optional String query for counting documents. Only documents matching it will be counted. If unspecified, all documents are counted.+++ |  +++#[payload]+++ |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Collection Name a| String |  +++The target collection+++ |  | x
+| Condition Query a| Binary |  +++The optional String query for counting documents. Only documents matching it will be counted. If unspecified, all documents are counted.+++ |  +++#[payload]+++ |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -259,10 +258,10 @@ Creates a new collection. If the collection already exists, a MongoException wil
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection to create+++ |  | x
-| Capped a| Boolean |  +++if the collection will be capped+++ |  +++false+++ |
-| Max Objects a| Number |  +++the maximum number of documents the new collection is able to contain+++ |  |
-| Collection Size a| Number |  +++the maximum size of the new collection+++ |  |
+| Collection Name a| String |  +++The name of the collection to create+++ |  | x
+| Capped a| Boolean |  +++If the collection will be capped+++ |  +++false+++ |
+| Max Objects a| Number |  +++The maximum number of documents the new collection is able to contain+++ |  |
+| Collection Size a| Number |  +++The maximum size of the new collection+++ |  |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -323,9 +322,9 @@ Creates a new MuleGridFSFile in the database, saving the given content, filename
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Content a| Binary |  +++the mandatory content of the new gridfs file. It may be a java.io.File, a byte[] or an InputStream.+++ |  +++#[payload]+++ |
-| Filename a| String |  +++the mandatory name of new file.+++ |  | x
-| Metadata a| Binary |  +++the optional String metadata of the new content type+++ |  |
+| Content a| Binary |  +++The mandatory content of the new gridfs file. It may be a java.io.File, a byte[] or an InputStream.+++ |  +++#[payload]+++ |
+| Filename a| String |  +++The mandatory name of new file.+++ |  | x
+| Metadata a| Binary |  +++The optional String metadata of the new content type+++ |  |
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -394,12 +393,12 @@ Creates a new index
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection where the index will be created+++ |  | x
-| Field Name a| String |  +++the name of the field which will be indexed+++ |  | x
+| Collection Name a| String |  +++The name of the collection where the index will be created+++ |  | x
+| Field Name a| String |  +++The name of the field which will be indexed+++ |  | x
 | Order a| Enumeration, one of:
 
 ** ASC
-** DESC |  +++the indexing order+++ |  +++ASC+++ |
+** DESC |  +++The indexing order+++ |  +++ASC+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -460,7 +459,7 @@ Deletes a collection and all the objects it contains. If the collection does not
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection to drop+++ |  | x
+| Collection Name a| String |  +++The name of the collection to drop+++ |  | x
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -581,8 +580,8 @@ Drops an existing index
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection where the index is+++ |  | x
-| Index Name a| String |  +++the name of the index to drop+++ |  | x
+| Collection Name a| String |  +++The name of the collection where the index is+++ |  | x
+| Index Name a| String |  +++The name of the index to drop+++ |  | x
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -643,11 +642,11 @@ Executes a dump of the database to the specified output directory. If no output 
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Output Directory a| String |  +++output directory path, if no output directory is provided the default /dump directory is assumed+++ |  +++dump+++ |
-| Output Name a| String |  +++output file name, if it's not specified the database name is used+++ |  |
-| Zip a| Boolean |  +++whether to zip the created dump file or not+++ |  +++false+++ |
-| Oplog a| Boolean |  +++point in time backup (requires an oplog)+++ |  +++false+++ |
-| Threads a| Number |  +++amount of threads to execute the dump+++ |  +++5+++ |
+| Output Directory a| String |  +++Output directory path, if no output directory is provided the default /dump directory is assumed+++ |  +++dump+++ |
+| Output Name a| String |  +++Output file name, if it's not specified the database name is used+++ |  |
+| Zip a| Boolean |  +++Whether to zip the created dump file or not+++ |  +++false+++ |
+| Oplog a| Boolean |  +++Point in time backup (requires an oplog)+++ |  +++false+++ |
+| Threads a| Number |  +++Amount of threads to execute the dump+++ |  +++5+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -699,7 +698,7 @@ Executes a dump of the database to the specified output directory. If no output 
 `<mongo:execute-command>`
 
 +++
-Executes a command on the database
+Executes a command on the database.
 +++
 
 === Parameters
@@ -772,7 +771,7 @@ Executes a command on the database
 `<mongo:exists-collection>`
 
 +++
-Answers if a collection exists given its name
+Answers if a collection exists given its name.
 +++
 
 === Parameters
@@ -781,7 +780,7 @@ Answers if a collection exists given its name
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection+++ |  +++#[payload]+++ |
+| Collection Name a| String |  +++The name of the collection+++ |  +++#[payload]+++ |
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -850,17 +849,17 @@ Finds all documents that match a given query. If no query is specified, all docu
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the target collection+++ |  | x
-| Condition Query a| Binary |  +++the optional String query document. If unspecified, all documents are returned.+++ |  +++#[payload]+++ |
-| Fields a| Array of String |  +++alternative way of passing fields as a literal List+++ |  |
-| Num To Skip a| Number |  +++number of documents skip (offset)+++ |  |
-| Result Limit a| Number |  +++limit of documents to return+++ |  |
-| Sort By a| Binary |  +++indicates the String used to sort the results+++ |  |
-| Return Id a| Boolean |  +++boolean that indicates if a Id is return in the response+++ |  +++true+++ |
+| Collection Name a| String |  +++The target collection+++ |  | x
+| Condition Query a| Binary |  +++The optional String query document. If unspecified, all documents are returned.+++ |  +++#[payload]+++ |
+| Fields a| Array of String |  +++Alternative way of passing fields as a literal List+++ |  |
+| Num To Skip a| Number |  +++Number of documents skip (offset)+++ |  |
+| Result Limit a| Number |  +++Limit of documents to return+++ |  |
+| Sort By a| Binary |  +++Indicates the String used to sort the results+++ |  |
+| Return Id a| Boolean |  +++Boolean that indicates if an ID is returned in the response+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
 * non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -919,7 +918,7 @@ Finds all documents that match a given query. If no query is specified, all docu
 `<mongo:find-files>`
 
 +++
-Lists all the files that match the given query
+Lists all the files that match the given query.
 +++
 
 === Parameters
@@ -928,8 +927,8 @@ Lists all the files that match the given query
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Find Query a| Binary |  +++a String query+++ |  | x
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Find Query a| Binary |  +++A String query+++ |  | x
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -997,20 +996,20 @@ Finds and update the first document that matches a given query. When returnNew =
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the target collection+++ |  | x
-| Find Query a| Binary |  +++the String query that the returned object matches.+++ |  |
-| Content To Update a| Binary |  +++the String mandatory object that will replace that one which matches the query+++ |  | x
-| Fields a| Array of String |  +++alternative way of passing fields as a literal List+++ |  |
+| Collection Name a| String |  +++The target collection+++ |  | x
+| Find Query a| Binary |  +++The String query that the returned object matches.+++ |  |
+| Content To Update a| Binary |  +++The String mandatory object that will replace that one which matches the query+++ |  | x
+| Fields a| Array of String |  +++Alternative way of passing fields as a literal List+++ |  |
 | Return New Document a| Boolean |  +++Flag to specify if the returning org.bson.Document should be the updated document instead of the original. Defaults to false, returning the document before modifications+++ |  +++false+++ |
-| Sort By a| Binary |  +++indicates the String used to sort the results.+++ |  |
-| Remove a| Boolean |  +++removes the specified in the query field. Defaults to false+++ |  +++false+++ |
-| Upsert a| Boolean |  +++whether the database should create the element if it does not exist+++ |  +++false+++ |
-| Bypass Document Validation a| Boolean |  +++lets you update documents that do not meet the validation requirements. Defaults to false+++ |  +++false+++ |
-| Return Id a| Boolean |  +++boolean that indicates if a Id is return in the response+++ |  +++false+++ |
+| Sort By a| Binary |  +++Indicates the String used to sort the results.+++ |  |
+| Remove a| Boolean |  +++Removes the specified in the query field. Defaults to false.+++ |  +++false+++ |
+| Upsert a| Boolean |  +++Whether the database should create the element if it does not exist+++ |  +++false+++ |
+| Bypass Document Validation a| Boolean |  +++Lets you update documents that do not meet the validation requirements. Defaults to false+++ |  +++false+++ |
+| Return Id a| Boolean |  +++Boolean that indicates if an ID is returned in the response.+++ |  +++false+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+* non-repeatable-stream |  +++Configure to use repeatable or non-repeatable streams.+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1069,7 +1068,7 @@ Finds and update the first document that matches a given query. When returnNew =
 `<mongo:find-one-document>`
 
 +++
-Finds the first document that matches a given query. Throws a MongoException if no one matches the given query
+Finds the first document that matches a given query. Throws a MongoException if no one matches the given query.
 +++
 
 === Parameters
@@ -1078,14 +1077,14 @@ Finds the first document that matches a given query. Throws a MongoException if 
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the target collection+++ |  | x
-| Find Query a| Binary |  +++the mandatory String query document that the returned object matches.+++ |  +++#[payload]+++ |
-| Fields a| Array of String |  +++alternative way of passing fields as a literal List+++ |  |
+| Collection Name a| String |  +++The target collection+++ |  | x
+| Find Query a| Binary |  +++The mandatory String query document that the returned object matches.+++ |  +++#[payload]+++ |
+| Fields a| Array of String |  +++Alternative way of passing fields as a literal List+++ |  |
 | Fail On Not Found a| Boolean |  +++Flag to specify if an exception will be thrown when no object is found. For backward compatibility the default value is true.+++ |  +++true+++ |
-| Return Id a| Boolean |  +++boolean that indicates if a Id is return in the response+++ |  +++true+++ |
+| Return Id a| Boolean |  +++Boolean that indicates if an ID is returned in the response+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
+* non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -1154,7 +1153,7 @@ Answers the first file that matches the given query. If no object matches it, a 
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Find Query a| Binary |  +++the String mandatory query+++ |  | x
+| Find Query a| Binary |  +++The String mandatory query+++ |  | x
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -1223,10 +1222,10 @@ Answers an inputstream to the contents of the first file that matches the given 
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| File Id a| <<MuleBsonObjectId>> |  +++the MuleBsonObjectId of the file to be deleted+++ |  +++#[payload]+++ |
+| File Id a| <<MuleBsonObjectId>> |  +++The MuleBsonObjectId of the file to be deleted+++ |  +++#[payload]+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
+* non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -1286,7 +1285,7 @@ Answers an inputstream to the contents of the first file that matches the given 
 `<mongo:incremental-dump>`
 
 +++
-Executes an incremental dump of the database
+Executes an incremental dump of the database.
 +++
 
 === Parameters
@@ -1295,8 +1294,8 @@ Executes an incremental dump of the database
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Output Directory a| String |  +++output directory path, if no output directory is provided the default /dump directory is assumed+++ |  +++dump+++ |
-| Incremental Timestamp File a| String |  +++file that keeps track of the last timestamp processed, if no file is provided one is created on the output directory+++ |  |
+| Output Directory a| String |  +++Output directory path, if no output directory is provided the default /dump directory is assumed+++ |  +++dump+++ |
+| Incremental Timestamp File a| String |  +++File that keeps track of the last timestamp processed, if no file is provided one is created on the output directory+++ |  |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -1348,7 +1347,7 @@ Executes an incremental dump of the database
 `<mongo:insert-document>`
 
 +++
-Inserts a document in a collection, setting its id if necessary.
+Inserts a document in a collection, setting its ID if necessary.
 +++
 
 === Parameters
@@ -1357,8 +1356,8 @@ Inserts a document in a collection, setting its id if necessary.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection where to insert the given document.+++ |  | x
-| Document a| Binary |  +++a String instance.+++ |  +++#[payload]+++ |
+| Collection Name a| String |  +++The name of the collection where to insert the given document.+++ |  | x
+| Document a| Binary |  +++A String instance.+++ |  +++#[payload]+++ |
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -1418,7 +1417,7 @@ Inserts a document in a collection, setting its id if necessary.
 `<mongo:insert-documents>`
 
 +++
-Inserts a list of documents in a collection, setting its id if necessary.
+Inserts a list of documents in a collection, setting its ID if necessary.
 +++
 
 === Parameters
@@ -1427,13 +1426,13 @@ Inserts a list of documents in a collection, setting its id if necessary.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection where to insert the given document.+++ |  | x
-| Documents a| Binary |  +++a java.util.List of String.+++ |  +++#[payload]+++ |
-| Write Ordered a| Boolean |  +++indicates if the list of write operations is ordered or unordered. By default, ff an error occurs during the processing of one of the write operations, MongoDB will return without processing any remaining write operations in the list.+++ |  +++false+++ |
+| Collection Name a| String |  +++The name of the collection where to insert the given document.+++ |  | x
+| Documents a| Binary |  +++A java.util.List of String.+++ |  +++#[payload]+++ |
+| Write Ordered a| Boolean |  +++Indicates if the list of write operations is ordered or unordered. By default, ff an error occurs during the processing of one of the write operations, MongoDB will return without processing any remaining write operations in the list.+++ |  +++false+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+* non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1492,7 +1491,7 @@ Inserts a list of documents in a collection, setting its id if necessary.
 `<mongo:list-collections>`
 
 +++
-Lists names of collections available at this database
+Lists names of collections available at this database.
 +++
 
 === Parameters
@@ -1503,8 +1502,8 @@ Lists names of collections available at this database
 | Configuration | String | The name of the configuration to use. | | x
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+* non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1573,7 +1572,7 @@ Lists all the files that match the given query, sorting them by filename. If no 
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Find Query a| Binary |  +++the String optional query+++ |  | x
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1632,7 +1631,7 @@ Lists all the files that match the given query, sorting them by filename. If no 
 `<mongo:list-indices>`
 
 +++
-List existent indices in a collection
+List existent indices in a collection.
 +++
 
 === Parameters
@@ -1641,11 +1640,11 @@ List existent indices in a collection
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection+++ |  | x
+| Collection Name a| String |  +++The name of the collection+++ |  | x
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
 * non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1703,9 +1702,10 @@ List existent indices in a collection
 == Map Reduce Objects
 `<mongo:map-reduce-objects>`
 
-+++
-Transforms a collection into a collection of aggregated groups, by applying a supplied element-mapping function to each element, that transforms each one into a key-value pair, grouping the resulting pairs by key, and finally reducing values in each group applying a suppling 'reduce' function. Each supplied function is coded in JavaScript. Note that the correct way of writing those functions may not be obvious; please consult MongoDB documentation for writing them.
-+++
+Transforms a collection into a collection of aggregated groups, by applying a supplied element-mapping function to each element, that transforms each one into a key-value pair, grouping the resulting pairs by key, and finally reducing values in each group applying a supplying `reduce` function. 
+
+Each supplied function is coded in JavaScript. Note that the correct way of writing those functions may not be obvious;  consult MongoDB documentation for writing them.
+
 
 === Parameters
 
@@ -1713,14 +1713,14 @@ Transforms a collection into a collection of aggregated groups, by applying a su
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection to map and reduce+++ |  | x
-| Mapping Function a| String |  +++a JavaScript encoded mapping function+++ |  | x
-| Reduce Function a| String |  +++a JavaScript encoded reducing function+++ |  | x
-| Output Collection a| String |  +++the name of the output collection to write the results, replacing previous collection if existed, mandatory when results may be larger than 16MB. If outputCollection is unspecified, the computation is performed in-memory and not persisted.+++ |  |
+| Collection Name a| String |  +++The name of the collection to map and reduce+++ |  | x
+| Mapping Function a| String |  +++A JavaScript encoded mapping function+++ |  | x
+| Reduce Function a| String |  +++A JavaScript encoded reducing function+++ |  | x
+| Output Collection a| String |  +++The name of the output collection to write the results, replacing previous collection if existed, mandatory when results may be larger than 16 MB. If outputCollection is unspecified, the computation is performed in-memory and not persisted.+++ |  |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+* non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1788,8 +1788,8 @@ Removes all the documents that match the a given optional query. If query is not
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the collection whose elements will be removed+++ |  | x
-| Find Query a| Binary |  +++the optional String query object. Documents that match it will be removed.+++ |  +++#[payload]+++ |
+| Collection Name a| String |  +++The collection whose elements will be removed+++ |  | x
+| Find Query a| Binary |  +++The optional String query object. Documents that match it will be removed.+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -1841,7 +1841,7 @@ Removes all the documents that match the a given optional query. If query is not
 `<mongo:remove-files>`
 
 +++
-Removes the file that matches the given file id. If no file id is specified, all files are removed
+Removes the file that matches the given file ID. If no file ID is specified, all files are removed.
 +++
 
 === Parameters
@@ -1850,7 +1850,7 @@ Removes the file that matches the given file id. If no file id is specified, all
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| File Id a| <<MuleBsonObjectId>> |  +++the MuleBsonObjectId of the file to be deleted+++ |  +++#[payload]+++ |
+| File Id a| <<MuleBsonObjectId>> |  +++The MuleBsonObjectId of the file to be deleted+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -1911,9 +1911,9 @@ Takes the output from the dump and restores it. Indexes will be created on a res
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Input Path a| String |  +++input path to the dump files, it can be a directory, a zip file or just a bson file+++ |  +++dump+++ |
-| Drop Collection a| Boolean |  +++whether to drop existing collections before restore+++ |  +++false+++ |
-| Oplog Replay a| Boolean |  +++replay oplog for point-in-time restore+++ |  +++false+++ |
+| Input Path a| String |  +++Input path to the dump files, it can be a directory, a zip file or just a BSON file+++ |  +++dump+++ |
+| Drop Collection a| Boolean |  +++Whether to drop existing collections before restore+++ |  +++false+++ |
+| Oplog Replay a| Boolean |  +++Replay oplog for point-in-time restore+++ |  +++false+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -1965,7 +1965,7 @@ Takes the output from the dump and restores it. Indexes will be created on a res
 `<mongo:save-document>`
 
 +++
-Inserts or updates a document based on its object _id.
+Inserts or updates a document based on its object ID.
 +++
 
 === Parameters
@@ -1974,8 +1974,8 @@ Inserts or updates a document based on its object _id.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the collection where to insert the object+++ |  | x
-| Document a| Binary |  +++the mandatory String document to insert.+++ |  +++#[payload]+++ |
+| Collection Name a| String |  +++The collection where to insert the object+++ |  | x
+| Document a| Binary |  +++The mandatory String document to insert.+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
 |===
@@ -2036,13 +2036,13 @@ Updates documents that matches the given query. If query is not specified, all d
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection to update+++ |  | x
-| Find Query a| Binary |  +++the String query object used to detect the element to update.+++ |  |
-| Content To Update a| Binary |  +++the String mandatory object that will replace that one which matches the query.+++ |  | x
-| Multiple Update a| Boolean |  +++if all or just the first document matching the query will be updated+++ |  +++true+++ |
+| Collection Name a| String |  +++The name of the collection to update+++ |  | x
+| Find Query a| Binary |  +++The String query object used to detect the element to update.+++ |  |
+| Content To Update a| Binary |  +++The String mandatory object that will replace that one which matches the query.+++ |  | x
+| Multiple Update a| Boolean |  +++If all or just the first document matching the query will be updated+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
+* non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -2111,15 +2111,15 @@ Update documents using a mongo function. If query is not specified, all document
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection to update+++ |  | x
-| Function a| String |  +++the function used to execute the update+++ |  | x
-| Find Query a| Binary |  +++the String query document used to detect the element to update.+++ |  |
-| Content To Update a| Binary |  +++the String mandatory document that will replace that one which matches the query.+++ |  | x
-| Upsert a| Boolean |  +++if the database should create the element if it does not exist.+++ |  +++false+++ |
-| Multiple Update a| Boolean |  +++if all or just the first document matching the query will be updated.+++ |  +++true+++ |
+| Collection Name a| String |  +++The name of the collection to update+++ |  | x
+| Function a| String |  +++The function used to execute the update+++ |  | x
+| Find Query a| Binary |  +++The String query document used to detect the element to update.+++ |  |
+| Content To Update a| Binary |  +++The String mandatory document that will replace that one which matches the query.+++ |  | x
+| Upsert a| Boolean |  +++If the database should create the element if it does not exist.+++ |  +++false+++ |
+| Multiple Update a| Boolean |  +++If all or just the first document matching the query will be updated.+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
+* non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -2188,15 +2188,15 @@ Update documents using one or more mongo function(s). If query is not specified,
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Collection Name a| String |  +++the name of the collection to update+++ |  | x
-| Find Query a| Binary |  +++the String query document used to detect the element to update+++ |  |
-| Functions a| Binary |  +++the String of functions used to execute the update. e.g. &lt;$set,{"key":123}&gt;+++ |  | x
-| Upsert a| Boolean |  +++whether the database should create the element if it does not exist+++ |  +++false+++ |
-| Multiple Update a| Boolean |  +++if all or just the first document matching the query will be updated+++ |  +++true+++ |
+| Collection Name a| String |  +++The name of the collection to update+++ |  | x
+| Find Query a| Binary |  +++The String query document used to detect the element to update+++ |  |
+| Functions a| Binary |  +++The String of functions used to execute the update. e.g. &lt;$set,{"key":123}&gt;+++ |  | x
+| Upsert a| Boolean |  +++Whether the database should create the element if it does not exist+++ |  +++false+++ |
+| Multiple Update a| Boolean |  +++If all or just the first document matching the query will be updated+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+* non-repeatable-stream | Configure to use repeatable or non-repeatable streams. |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -2258,28 +2258,30 @@ Update documents using one or more mongo function(s). If query is not specified,
 [cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
 |===
 | Field | Type | Description | Default Value | Required
-| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy |  |
+| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy. |  |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> | The reconnection strategy to use |  |
 |===
 
 [[reconnect]]
-==== Reconnect
+=== Reconnect
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Frequency a| Number | How often (in ms) to reconnect |  |
-| Count a| Number | How many reconnection attempts to make |  |
+| Frequency a| Number | How often in milliseconds to reconnect. | |
+| Count a| Number | How many reconnection attempts to make. | |
+| blocking |Boolean |If false, the reconnection strategy runs in a separate, non-blocking thread. |true |
 |===
 
 [[reconnect-forever]]
 === Reconnect Forever
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Frequency a| Number | How often (in ms) to reconnect |  |
+| Frequency a| Number | How often in milliseconds to reconnect. | |
+| blocking |Boolean |If false, the reconnection strategy runs in a separate, non-blocking thread. |true |
 |===
 
 [[ExpirationPolicy]]
@@ -2307,7 +2309,7 @@ Update documents using one or more mongo function(s). If query is not specified,
 |===
 | Field | Type | Description | Default Value | Required
 | Initial Buffer Size a| Number | This is the amount of memory that will be allocated in order to consume the stream and provide random access to it. If the stream contains more data than can be fit into this buffer, then it will be expanded by according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. |  |
-| Buffer Size Increment a| Number | This is by how much will be buffer size by expanded if it exceeds its initial size. Setting a value of zero or lower will mean that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error will be raised when the buffer gets full. |  |
+| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower will mean that the buffer should not expand, and that a STREAM_MAXIMUM_SIZE_EXCEEDED error will be raised when the buffer gets full. |  |
 | Max Buffer Size a| Number | This is the maximum amount of memory that will be used. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error will be raised. A value lower or equal to zero means no limit. |  |
 | Buffer Unit a| Enumeration, one of:
 
@@ -2333,7 +2335,7 @@ Update documents using one or more mongo function(s). If query is not specified,
 |===
 
 [[MuleBsonObjectId]]
-=== Mule Bson Object Id
+=== Mule BSON Object ID
 
 [cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
 |===
@@ -2342,7 +2344,7 @@ Update documents using one or more mongo function(s). If query is not specified,
 |===
 
 [[MongoIdObject]]
-=== Mongo Id Object
+=== Mongo ID Object
 
 [cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
 |===

--- a/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
+++ b/modules/ROOT/pages/mongodb/mongodb-connector-reference.adoc
@@ -28,7 +28,7 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 * <<config_connection-string, Connection String>>
  | The connection types that can be provided to this configuration. | | x
 | Expiration Policy a| <<ExpirationPolicy>> |  +++Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. The runtime actually purges the instances when it sees fit.+++ |  |
-| Enable Metadata a| Boolean |  +++collectionMetadataSamples: Stores templates to build metadata based on the document parameters `union Key (String): Collection Name`. `List<String>:` List of ObjectIDs documents in a collection.+++ |  +++true+++ |
+| Enable Metadata a| Boolean a|  `collectionMetadataSamples`: Stores templates to build metadata based on the document parameters `union Key (String): Collection Name`. `List<String>:` List of ObjectIDs documents in a collection. |  +++true+++ |
 | Collection Metadata samples a| Object |  |  |
 |===
 
@@ -42,17 +42,17 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
 |===
 | Name | Type | Description | Default Value | Required
-| Servers (host:port) a| String a|  A list of MongoDB instance, with the format `host:port<`, separated by commas. Example: `+127.0.0.1:27017+`, `+192.168.1.2:27017+`  |  `localhost:27017` |
+| Servers (host:port) a| String a|  A list of MongoDB instance, with the format `host:port`, separated by commas. Example: `+127.0.0.1:27017+`, `+192.168.1.2:27017+`  a|  `localhost:27017` |
 | Connections Per Host a| Number |  +++The number of connections allowed per host (the pool size, per host)+++ |  +++100+++ |
-| Threads Allowed To Block For Connection Multiplier a| Number |  +++Multiplier for connectionsPerHost for # of threads that can block.+++ |  +++5+++ |
-| Max Wait Time a| Number |  +++The max wait time for a blocking thread for a connection from the pool in ms.+++ |  +++120000+++ |
+| Threads Allowed To Block For Connection Multiplier a| Number |  +++Multiplier for connectionsPerHost for number of threads that can block.+++ |  +++5+++ |
+| Max Wait Time a| Number |  +++The max wait time for a blocking thread for a connection from the pool in milliseconds.+++ |  +++120000+++ |
 | Connect Timeout a| Number |  +++The connection timeout in milliseconds; this is for establishing the socket connections (open). 0 is default and infinite.+++ |  +++30000+++ |
 | Socket Timeout a| Number |  +++The socket timeout. 0 is default and infinite.+++ |  +++0+++ |
 | Username a| String | +++The username to use for authentication.+++  |  ++++++ |
-| Password a| String |  +++The password to use for authentication. If the password is null or whitespaces only, the connector won't use authentication and username must be empty too.+++ |  |
+| Password a| String |  +++The password to use for authentication. If the password is null or whitespaces only, the connector won't use authentication, and username must be empty too.+++ |  |
 | Database a| String | +++Name of the database+++ |  | x
 | SSL a| Boolean |  +++Enables an SSL connection. It is disabled by default.+++ |  +++false+++ |
-| Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy+++ |  |
+| Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy.+++ |  |
 |===
 
 [[config_connection-string]]
@@ -65,10 +65,10 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 |===
 | Name | Type | Description | Default Value | Required
 | Connection URI a| String |  |  | x
-| Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy+++ |  |
+| Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy.+++ |  |
 |===
 
-==== Associated Operations
+== Supported Operations
 
 * <<addUser>>
 * <<countDocuments>>
@@ -102,8 +102,6 @@ MongoDB is an open source, high-performance, schema-free, document-oriented data
 * <<updateDocumentsByFunction>>
 * <<updateDocumentsByFunctions>>
 
-
-
 == Operations
 
 [[addUser]]
@@ -124,8 +122,8 @@ Adds a new user to a database.
 | Password a| String |  +++Password that will be used for authentication+++ |  | x
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+* non-repeatable-stream |  Configure to enable repeatable or non-repeatable streams. |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -327,10 +325,10 @@ Creates a new MuleGridFSFile in the database, saving the given content, filename
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Content a| Binary |  +++The mandatory content of the new gridfs file. It may be a java.io.File, a byte[] or an InputStream.+++ |  +++#[payload]+++ |
+| Content a| Binary a|  The mandatory content of the new gridfs file. It may be a `java.io.File`, a `byte[]`, or an `InputStream`. |  +++#[payload]+++ |
 | Filename a| String |  +++The mandatory name of new file.+++ |  | x
 | Metadata a| Binary |  +++The optional String metadata of the new content type+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -647,7 +645,7 @@ Executes a dump of the database to the specified output directory. If no output 
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Output Directory a| String |  +++Output directory path, if no output directory is provided the default /dump directory is assumed+++ |  +++dump+++ |
+| Output Directory a| String a|  Output directory path, if no output directory is provided the default `/dump` directory is assumed. |  +++dump+++ |
 | Output Name a| String |  +++Output file name, if it's not specified the database name is used+++ |  |
 | Zip a| Boolean |  +++Whether to zip the created dump file or not+++ |  +++false+++ |
 | Oplog a| Boolean |  +++Point in time backup (requires an oplog)+++ |  +++false+++ |
@@ -716,8 +714,8 @@ Executes a command on the database.
 | Command Value a| String |  +++The value for the command+++ |  |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+* non-repeatable-stream |  Configure to enable repeatable or non-repeatable streams. |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -786,7 +784,7 @@ Answers if a collection exists given its name.
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  +++The name of the collection+++ |  +++#[payload]+++ |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -863,7 +861,7 @@ Finds all documents that match a given query. If no query is specified, all docu
 | Return Id a| Boolean |  +++Boolean that indicates if an ID is returned in the response+++ |  +++true+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
+* non-repeatable-stream |  Configure to enable repeatable or non-repeatable streams. |  |
 | Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -991,9 +989,7 @@ Lists all the files that match the given query.
 == Find One And Update Document
 `<mongo:find-one-and-update-document>`
 
-+++
-Finds and update the first document that matches a given query. When returnNew = true, returns the updated document instead of the original document.
-+++
+Finds and update the first document that matches a given query. When `returnNew = true`, returns the updated document instead of the original document.
 
 === Parameters
 
@@ -1005,7 +1001,7 @@ Finds and update the first document that matches a given query. When returnNew =
 | Find Query a| Binary |  +++The String query that the returned object matches.+++ |  |
 | Content To Update a| Binary |  +++The String mandatory object that will replace that one which matches the query+++ |  | x
 | Fields a| Array of String |  +++Alternative way of passing fields as a literal List+++ |  |
-| Return New Document a| Boolean |  +++Flag to specify if the returning org.bson.Document should be the updated document instead of the original. Defaults to false, returning the document before modifications+++ |  +++false+++ |
+| Return New Document a| Boolean a|  Flag to specify if the returning `org.bson.Document` should be the updated document instead of the original. Defaults to false, returning the document before modifications. |  +++false+++ |
 | Sort By a| Binary |  +++Indicates the String used to sort the results.+++ |  |
 | Remove a| Boolean |  +++Removes the specified in the query field. Defaults to false.+++ |  +++false+++ |
 | Upsert a| Boolean |  +++Whether the database should create the element if it does not exist+++ |  +++false+++ |
@@ -1013,7 +1009,7 @@ Finds and update the first document that matches a given query. When returnNew =
 | Return Id a| Boolean |  +++Boolean that indicates if an ID is returned in the response.+++ |  +++false+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure to use repeatable or non-repeatable streams.+++ |  |
+* non-repeatable-stream |  Configure to enable repeatable or non-repeatable streams. |  |
 | Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -1090,7 +1086,7 @@ Finds the first document that matches a given query. Throws a MongoException if 
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
 * non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1159,7 +1155,7 @@ Answers the first file that matches the given query. If no object matches it, a 
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Find Query a| Binary |  +++The String mandatory query+++ |  | x
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1299,7 +1295,7 @@ Executes an incremental dump of the database.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Output Directory a| String |  +++Output directory path, if no output directory is provided the default /dump directory is assumed+++ |  +++dump+++ |
+| Output Directory a| String a|  Output directory path, if no output directory is provided the default `/dump` directory is assumed. |  +++dump+++ |
 | Incremental Timestamp File a| String |  +++File that keeps track of the last timestamp processed, if no file is provided one is created on the output directory+++ |  |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1363,7 +1359,7 @@ Inserts a document in a collection, setting its ID if necessary.
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  +++The name of the collection where to insert the given document.+++ |  | x
 | Document a| Binary |  +++A String instance.+++ |  +++#[payload]+++ |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -1433,7 +1429,7 @@ Inserts a list of documents in a collection, setting its ID if necessary.
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  +++The name of the collection where to insert the given document.+++ |  | x
 | Documents a| Binary |  +++A java.util.List of String.+++ |  +++#[payload]+++ |
-| Write Ordered a| Boolean |  +++Indicates if the list of write operations is ordered or unordered. By default, ff an error occurs during the processing of one of the write operations, MongoDB will return without processing any remaining write operations in the list.+++ |  +++false+++ |
+| Write Ordered a| Boolean |  +++Indicates if the list of write operations is ordered or unordered. By default, if an error occurs during the processing of one of the write operations, MongoDB will return without processing any remaining write operations in the list.+++ |  +++false+++ |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
 * non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
@@ -1648,7 +1644,7 @@ List existent indices in a collection.
 | Collection Name a| String |  +++The name of the collection+++ |  | x
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior+++ |  |
+* non-repeatable-stream |  Configure to enable repeatable or non-repeatable streams. |  |
 | Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
@@ -2048,7 +2044,7 @@ Updates documents that matches the given query. If query is not specified, all d
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
 * non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |
@@ -2125,7 +2121,7 @@ Update documents using a mongo function. If query is not specified, all document
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
 * non-repeatable-stream |  Configure to use repeatable or non-repeatable streams. |  |
-| Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  |
+| Target Variable a| String |  +++The name of a variable in which the operation's output will be placed+++ |  |
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ |
 | Reconnection Strategy a| * <<reconnect>>
 * <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors+++ |  |


### PR DESCRIPTION
Changes included in this PR reflects differences between tags 5.3.0 and 5.3.1. When I compared **latest** version on github and tag 5.3.1 there were **missing** these additional sections:
```
Execute Generic Command
Sources: modified object, delete object, new object
TLS
Redrive policy
```
These were the most obvious ones but there could be other minor changes which I missed. Could you please check that and tell me how to resolve this issue ?