### PR TITLE
Updating the output application/ type

### DIFF
--- a/modules/ROOT/pages/twilio/twilio-connector.adoc
+++ b/modules/ROOT/pages/twilio/twilio-connector.adoc
@@ -167,7 +167,7 @@ This is the phone number you received from Twilio.
 [source,dataweave,linenums]
 ----
 %dw 2.0
-output application/x-www-form-urlencoded
+output application/java
 ---
 {
     Body: "You are now subscribed!",
@@ -189,7 +189,7 @@ output application/x-www-form-urlencoded
 [source,dataweave,linenums]
 ----
 %dw 2.0
-output application/x-www-form-urlencoded
+output application/java
 ---
 {
     Body: "",

--- a/modules/ROOT/pages/twilio/twilio-connector.adoc
+++ b/modules/ROOT/pages/twilio/twilio-connector.adoc
@@ -167,7 +167,7 @@ This is the phone number you received from Twilio.
 [source,dataweave,linenums]
 ----
 %dw 2.0
-output application/json
+output application/x-www-form-urlencoded
 ---
 {
     Body: "You are now subscribed!",
@@ -189,7 +189,7 @@ output application/json
 [source,dataweave,linenums]
 ----
 %dw 2.0
-output application/json
+output application/x-www-form-urlencoded
 ---
 {
     Body: "",


### PR DESCRIPTION
We recently did a workshop using Twilio connector. Upon following the instructions from MuleSoft's documentation, I constantly got errors while compiling a simple flow to send SMS. Upon looking at the Twilio Programmable SMS dashboard (Twilio Dev Account), the cURL request accepts '--data-urlencode' only for accepting To, From and Body.
Upon the changing the transform to output application/x-www-form-urlencoded, I was able to make the sms functionality work without any issues.