### PR TITLE
DOCS-5433 fixed release notes link

### DIFF
--- a/modules/ROOT/pages/ibm/ibm-ctg-connector.adoc
+++ b/modules/ROOT/pages/ibm/ibm-ctg-connector.adoc
@@ -18,7 +18,7 @@ This document assumes that you are familiar with IBM CTG, Mule, Anypoint Connect
 
 You need login credentials to test your connection to your target resource.
 
-For software requirements and compatibility information, see the xref:release-notes::connector/ibm-ctg-connector-release-notes.adoc[Release Notes].
+For software requirements and compatibility information, see the xref:release-notes::connector/ibm-ctg-connector-release-notes-mule-4.adoc[Release Notes].
 
 To use this connector with Maven, view the `pom.xml` dependency information in
 the *Dependency Snippets* in https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-ibm-ctg-connector/[Anypoint Exchange].
@@ -706,7 +706,7 @@ output application/json
 
 == See Also
 
-* Access the xref:release-notes::connector/ibm-ctg-connector-release-notes.adoc[IBM CICS Transaction Gateway Connector Release Notes]
+* Access the xref:release-notes::connector/ibm-ctg-connector-release-notes-mule-4.adoc[IBM CICS Transaction Gateway Connector Release Notes]
 * IBM's https://www.ibm.com/support/knowledgecenter/SSGMCP_5.3.0/com.ibm.cics.ts.java.doc/topics/dfhpjpart2.html[Developing Java applications for CICS]
 * High-level tutorial of JCA in https://www.ibm.com/developerworks/java/tutorials/j-jca/j-jca.html[Introduction to the J2EE Connector Architecture]
 * http://www.redbooks.ibm.com/Redbooks.nsf/domains/zsoftware?Open[Redbooks for the IBM Mainframe]


### PR DESCRIPTION
(Was incorrectly pointing to the Mule 3 version) -- DOCS-5433 is a larger jira for updating multiple versions of this doc. 
See: https://www.mulesoft.org/jira/browse/DOCS-5433