### PR TITLE
DOCS-5405 Salesforce 9.7.7 update

### DIFF
--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference-97.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference-97.adoc
@@ -2220,27 +2220,27 @@ Retrieves the list of individual records that have been created or updated withi
 
 [[getUpdatedObjects]]
 === Get Updated Objects
+
 `<salesforce:get-updated-objects>`
 
+Retrieves a list of records that have been updated between the last time this method was called and the current server's timestamp. 
 
-Retrieves the list of records that have been updated between the last time this method was called and now. This method will save the timestamp of the latest date covered by Salesforce represented by `GetUpdatedResult#latestDateCovered`. 
-
-IMPORTANT: In order to use this method in a reliable way user must ensure that right after this method returns the result is stored in a persistent way since the timestamp of the latest. To reset the latest update time use `resetUpdatedObjectsTimestamp(String)`.
-
+The Salesforce API ignores the seconds portion of dates, so subsequent calls of this operation should take place at a rate of at least one minute, otherwise the operation does not return any results for the subsequent calls.
 
 ==== Parameters
-[%header%autowidth.spread]
+
+[%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Type a| String |  Object type. The specified value must be a valid object for your organization. |  | x
-| Initial Time Window a| Number |  Time window (in minutes) used to calculate the start time (in time range) the first time this operation is called. For example, if initialTimeWindow equals 2, the start time is the current time (now) minus 2 minutes, then the range to retrieve the updated object is (now - 2 minutes; now). After first call the start time is calculated from the object store getting the last time this operation was exec |  | x
-| Fields a| Array of String |  The fields to retrieve for the updated objects |  | x
-| Update Headers a| <<RequestHeaders>> |  Salesforce Headers http://www.salesforce.com/us/developer/docs/api/Content/soap_headers.htm[More Info] |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` | 
+| Initial Time Window a| Number |  Time window in minutes used to calculate the start time (in a time range) the first time this operation is called. For example, if *Initial Time Window* equals 2, the start time is the current time (now) minus 2 minutes, then the range to retrieve the updated object is (now - 2 minutes; now). After the first call, the start time is calculated from the object store getting the last time this operation was executed. |  | x
+| Fields a| Array of String |  The fields to retrieve for the updated objects. |  | x
+| Update Headers a| <<RequestHeaders>> |  http://www.salesforce.com/us/developer/docs/api/Content/soap_headers.htm[Salesforce Headers] |  |
+| Target Variable a| String |  The name of a variable in which the operation's output is placed. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and the outcome of that expression is stored in the target variable. |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output

--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference-97.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference-97.adoc
@@ -2227,6 +2227,8 @@ Retrieves a list of records that have been updated between the last time this me
 
 The Salesforce API ignores the seconds portion of dates, so subsequent calls of this operation should take place at a rate of at least one minute, otherwise the operation does not return any results for the subsequent calls.
 
+For example, if a request is sent at `12:14:05` and the *Initial Time Window* field is set to 3 minutes, the *Get Updated Object* operation sends the Salesforce API this interval: `12:11:00 - 12:14:00`, after which the next request is `12:14:00 - 12:15:00` (if the operation is invoked after one minute).
+
 ==== Parameters
 
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/modules/ROOT/pages/salesforce/salesforce-connector-reference-97.adoc
+++ b/modules/ROOT/pages/salesforce/salesforce-connector-reference-97.adoc
@@ -2225,9 +2225,9 @@ Retrieves the list of individual records that have been created or updated withi
 
 Retrieves a list of records that have been updated between the last time this method was called and the current server's timestamp. 
 
-The Salesforce API ignores the seconds portion of dates, so subsequent calls of this operation should take place at a rate of at least one minute, otherwise the operation does not return any results for the subsequent calls.
+The Salesforce API ignores the seconds portion of dates, so subsequent calls of this operation take place at a rate of at least one minute. Subsequent calls within a minute do not return results.
 
-For example, if a request is sent at `12:14:05` and the *Initial Time Window* field is set to 3 minutes, the *Get Updated Object* operation sends the Salesforce API this interval: `12:11:00 - 12:14:00`, after which the next request is `12:14:00 - 12:15:00` (if the operation is invoked after one minute).
+For example, if a request is sent at `12:14:05` and the *Initial Time Window* field is set to 3 minutes, the *Get Updated Object* operation sends the Salesforce API this interval: `12:11:00 - 12:14:00`. Thereafter, the next request is `12:14:00 - 12:15:00` if the operation is invoked after one minute.
 
 ==== Parameters
 
@@ -2236,7 +2236,9 @@ For example, if a request is sent at `12:14:05` and the *Initial Time Window* fi
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Type a| String |  Object type. The specified value must be a valid object for your organization. |  | x
-| Initial Time Window a| Number |  Time window in minutes used to calculate the start time (in a time range) the first time this operation is called. For example, if *Initial Time Window* equals 2, the start time is the current time (now) minus 2 minutes, then the range to retrieve the updated object is (now - 2 minutes; now). After the first call, the start time is calculated from the object store getting the last time this operation was executed. |  | x
+| Initial Time Window a| Number |  Time window in minutes used to calculate the start time (in a time range) the first time this operation is called. 
+
+For example, if *Initial Time Window* is `2`, the start time is the current time (now) minus 2 minutes. The range to retrieve the updated object then becomes `now - 2 minutes; now`. After the first call, the start time is calculated from the object store value that provides the last time this operation executed. |  | x
 | Fields a| Array of String |  The fields to retrieve for the updated objects. |  | x
 | Update Headers a| <<RequestHeaders>> |  http://www.salesforce.com/us/developer/docs/api/Content/soap_headers.htm[Salesforce Headers] |  |
 | Target Variable a| String |  The name of a variable in which the operation's output is placed. |  |


### PR DESCRIPTION
See https://github.com/mulesoft/docs-connectors/pull/272#discussion_r304917706 for more info:
Starting with release 9.7.7(Mule 4) the description of GetUpdateObjects will change to this:
Retrieves the list of records that have been updated between the last time this method was called and the current server timestamp. Salesforce API ignores the seconds portion of the specified dates so subsequent calls of this operation should take place at a rate of at least one minute, otherwise the operation will not return any results for the subsequent calls. 
this is due to a bug fix that we implemented yesterday. There were some issues causing where missing messages or sometimes duplicates, and they were caused in fact because salesforce does not care for the SECONDS or MILLISECONDS passed in the requests. So we have updated the operation to send requests with an interval of at leas one minute. (if one request is sent at 12:14:05 and initialTimeWindow=3minutes we will in fact send to the api this interval: 12:11:00 - 12:14:00, after that the next request will be 12:14:00 - 12:15:00(if the operation is invoked after one minute))