### PR TITLE
Fixing broken links in Getting Started template.

### DIFF
--- a/modules/ROOT/pages/cassandra/cassandra-connector-get-started.adoc
+++ b/modules/ROOT/pages/cassandra/cassandra-connector-get-started.adoc
@@ -32,7 +32,7 @@ Requirements for using the connector:
 
 * Starting user - Use this Get Started to see where you can create a Mule application in xref:cassandra/cassandra-connector-design-center.adoc[Design Center] or xref:cassandra/cassandra-connector-studio.adoc[Anypoint Studio].
 * The xref:cassandra/cassandra-connector-config-topics.adoc[Configuration Topics] help you extend your understanding of Cassandra actions.
-* Power user - Read the xref:cassandra-connector-xml-maven.adoc[XML and Maven Support], xref:cassandra/cassandra-connector-config-topics.adoc[Configuration Topics], and xref:cassandra/cassandra-connector-examples.adoc[Example] documents.
+* Power user - Read the xref:cassandra/cassandra-connector-xml-maven.adoc[XML and Maven Support], xref:cassandra/cassandra-connector-config-topics.adoc[Configuration Topics], and xref:cassandra/cassandra-connector-examples.adoc[Example] documents.
 
 == Exchange Templates and Examples
 https://www.mulesoft.com/exchange/[Anypoint Exchange] provides templates

--- a/modules/ROOT/pages/cassandra/cassandra-connector-get-started.adoc
+++ b/modules/ROOT/pages/cassandra/cassandra-connector-get-started.adoc
@@ -30,12 +30,12 @@ Requirements for using the connector:
 
 == Audience
 
-* Starting user - Use this Get Started to see where you can create a Mule application in xref:cassandra/cassandra-design-center.adoc[Design Center] or xref:cassandra/cassandra-studio.adoc[Anypoint Studio].
-* The xref:cassandra/cassandra-config-topics.adoc[Configuration Topics] help you extend your understanding of Cassandra actions.
-* Power user - Read the xref:cassandra-connector-xml-maven.adoc[XML and Maven Support], xref:cassandra/cassandra-config-topics.adoc[Configuration Topics], and xref:cassandra/cassandra-use-cases.adoc[Example] documents.
+* Starting user - Use this Get Started to see where you can create a Mule application in xref:cassandra/cassandra-connector-design-center.adoc[Design Center] or xref:cassandra/cassandra-connector-studio.adoc[Anypoint Studio].
+* The xref:cassandra/cassandra-connector-config-topics.adoc[Configuration Topics] help you extend your understanding of Cassandra actions.
+* Power user - Read the xref:cassandra-connector-xml-maven.adoc[XML and Maven Support], xref:cassandra/cassandra-connector-config-topics.adoc[Configuration Topics], and xref:cassandra/cassandra-connector-examples.adoc[Example] documents.
 
 == Exchange Templates and Examples
-https://www.mulesoft.com/exchange/[Anypoint Exchange] provides templates  
+https://www.mulesoft.com/exchange/[Anypoint Exchange] provides templates
 you can use as a starting point for your app, as well as examples that illustrate
 a complete solution.
 
@@ -43,8 +43,8 @@ a complete solution.
 
 == Next
 
-Now that you've started, try using xref:cassandra/cassandra-design-center.adoc[Design Center] or
-xref:cassandra/cassandra-studio.adoc[Anypoint Studio].
+Now that you've started, try using xref:cassandra/cassandra-connector-design-center.adoc[Design Center] or
+xref:cassandra/cassandra-connector-studio.adoc[Anypoint Studio].
 
 == See Also
 


### PR DESCRIPTION
Was missing the complete link name for the xrefs.
