### PR TITLE
DOCS-5317 update

### DIFF
--- a/modules/ROOT/pages/sftp/sftp-documentation.adoc
+++ b/modules/ROOT/pages/sftp/sftp-documentation.adoc
@@ -1,11 +1,13 @@
-= SFTP Connector Reference
+= SFTP Connector Reference - Mule 4
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-+++
-Allows manipulating files through the FTP and SFTP.
-+++
+Support Category: Select
+
+SFTP Connector v1.2
+
+Allows manipulating files using FTP and SFTP.
 
 
 == Configurations
@@ -13,43 +15,56 @@ Allows manipulating files through the FTP and SFTP.
 [[config]]
 === Config
 
-+++
-Default configuration
-+++
+
+Default configuration.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-|Name | String | The name for this configuration. Connectors reference the configuration with this name. | | *x*{nbsp}
+|Name | String | The name for this configuration. Connectors reference the configuration with this name. | | x
 | Connection a| <<config_connection, SFTP Connection>>
- | The connection types that can be provided to this configuration. | | *x*{nbsp}
-| Default Write Encoding a| String |  |  | {nbsp}
-| Expiration Policy a| <<ExpirationPolicy>> |  +++Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. The runtime will actually purge the instances when it sees fit.+++ |  | {nbsp}
+ | The connection types to provide to this configuration. | | x
+| Default write encoding (Deprecated) a| String |  This parameter is deprecated and is not taken into account. |  | 
+| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to be read. This allows a file write to complete before processing. If no value is provided, the check is not performed. When enabled, Mule performs two size checks waiting the specified time between calls. If both checks return the same value, the file is ready to be read. This attribute works in tandem with the *Time Between Size Check Unit* field. |  | 
+| Time Between Size Check Unit a| Enumeration, one of:
+
+** NANOSECONDS
+** MICROSECONDS
+** MILLISECONDS
+** SECONDS
+** MINUTES
+** HOURS
+** DAYS |  A TimeUnit that qualifies the *Time Between Size Check* attribute.  Defaults to MILLISECONDS. |  MILLISECONDS | 
+| Expiration Policy a| <<ExpirationPolicy>> |  Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform expires the instance at the exact moment that it becomes eligible. The runtime purges the instances when it sees fit. |  | 
 |===
 
 == Connection Types
+
 [[config_connection]]
 === SFTP Connection
 
-+++
-An FileSystemProvider which provides instances of SftpFileSystem from instances of SftpConnector
-+++
+
+A `FileSystemProvider` that provides instances of `SftpFileSystem` from instances of `SftpConnector`.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Working Directory a| String |  +++The directory to be considered as the root of every relative path used with this connector. If not provided, it will default to the remote server default.+++ |  | {nbsp}
+| Working Directory a| String |  The directory to be considered as the root of every relative path used with this connector. If not provided, it defaults to the remote server default. |  | 
 | Preferred Authentication Methods a| Array of Enumeration, one of:
 
 ** GSSAPI_WITH_MIC
 ** PUBLIC_KEY
 ** KEYBOARD_INTERACTIVE
-** PASSWORD |  +++Set of authentication methods used by the SFTP client. Valid values are: SSAPI_WITH_MIC, PUBLIC_KEY, KEYBOARD_INTERACTIVE and PASSWORD.+++ |  | {nbsp}
-| Known Hosts File a| String |  +++If provided, the client will validate the server's key against the one in the referenced file. If the server key doesn't match the one in the file, the connection is aborted.+++ |  | {nbsp}
-| Sftp Proxy Config a| <<SftpProxyConfig>> |  +++If provided, a proxy is used for the connection.+++ |  | {nbsp}
-| Connection Timeout a| Number |  +++A scalar value representing the amount of time to wait before a connection attempt times out. This attribute works in tandem with #connectionTimeoutUnit. Defaults to 10+++ |  +++10+++ | {nbsp}
+** PASSWORD |  Set of authentication methods used by the SFTP client. Valid values are: GSSAPI_WITH_MIC, PUBLIC_KEY, KEYBOARD_INTERACTIVE and PASSWORD. |  | 
+| Known Hosts File a| String |  If provided, the client validates the server's key against the one in the referenced file. If the server key doesn't match the one in the file, the connection is aborted. |  | 
+| SFTP Proxy Config a| <<SftpProxyConfig>> |  If provided, a proxy is used for the connection. |  | 
+| Connection Timeout a| Number |  A scalar value representing the amount of time to wait before a connection attempt times out. This attribute works in tandem with *Connection Timeout Unit*.  Defaults to 10 seconds. |  10 | 
 | Connection Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -58,8 +73,8 @@ An FileSystemProvider which provides instances of SftpFileSystem from instances 
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  +++A TimeUnit which qualifies the #connectionTimeout attribute. Defaults to SECONDS+++ |  +++SECONDS+++ | {nbsp}
-| Response Timeout a| Number |  +++A scalar value representing the amount of time to wait before a request for data times out. This attribute works in tandem with #responseTimeoutUnit. Defaults to 10+++ |  +++10+++ | {nbsp}
+** DAYS |  A TimeUnit which qualifies the *Connection Timeout* attribute.  Defaults to SECONDS. |  SECONDS | 
+| Response Timeout a| Number |  A scalar value representing the amount of time to wait before a request for data times out. This attribute works in tandem with *Response Timeout Unit*.  Defaults to 10 seconds. |  10 | 
 | Response Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -68,383 +83,466 @@ An FileSystemProvider which provides instances of SftpFileSystem from instances 
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  +++A TimeUnit which qualifies the #responseTimeoutUnit attribute. Defaults to SECONDS+++ |  +++SECONDS+++ | {nbsp}
-| Host a| String |  +++The FTP server host, such as www.mulesoft.com, localhost, or 192.168.0.1, etc+++ |  | *x*{nbsp}
-| Port a| Number |  +++The port number of the SFTP server to connect on+++ |  +++22+++ | {nbsp}
-| Username a| String |  +++Username for the FTP Server. Required if the server is authenticated.+++ |  | {nbsp}
-| Password a| String |  +++Password for the FTP Server. Required if the server is authenticated.+++ |  | {nbsp}
-| Passphrase a| String |  +++The passphrase (password) for the identityFile if required. Notice that this parameter is ignored if #identityFile is not provided+++ |  | {nbsp}
-| Identity File a| String |  +++An identityFile location for a PKI private key.+++ |  | {nbsp}
+** DAYS |  A TimeUnit which qualifies the *Response Timeout* attribute.  Defaults to SECONDS. |  SECONDS | 
+| Host a| String |  The FTP server host, such as `www.mulesoft.com`, localhost, or 192.168.0.1, etc. |  | x
+| Port a| Number |  The port number of the SFTP server to connect on. |  22 | 
+| Username a| String |  Username for the FTP Server. Required if the server is authenticated. |  | 
+| Password a| String |  Password for the FTP Server. Required if the server is authenticated. |  | 
+| Passphrase a| String |  The pass phrase (password) for the identityFile if required. Notice that this parameter is ignored if #identityFile is not provided. |  | 
+| Identity File a| String |  An identityFile location for a PKI private key. |  | 
 | PRNG Algorithm a| Enumeration, one of:
 
 ** AUTOSELECT
 ** NativePRNG
 ** SHA1PRNG
 ** NativePRNGBlocking
-** NativePRNGNonBlocking |  +++The Pseudo Random Generator Algorithm to use+++ |  +++AUTOSELECT+++ | {nbsp}
-| Reconnection a| <<Reconnection>> |  +++When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy+++ |  | {nbsp}
-| Pooling Profile a| <<PoolingProfile>> |  +++Characteristics of the connection pool+++ |  | {nbsp}
+** NativePRNGNonBlocking |  The Pseudo Random Generator Algorithm to use. |  AUTOSELECT | 
+| Reconnection a| <<Reconnection>> |  When an app is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
+| Pooling Profile a| <<PoolingProfile>> |  Characteristics of the connection pool. |  | 
 |===
 
-==== Associated Operations
-* <<copy>> {nbsp}
-* <<createDirectory>> {nbsp}
-* <<delete>> {nbsp}
-* <<list>> {nbsp}
-* <<move>> {nbsp}
-* <<read>> {nbsp}
-* <<rename>> {nbsp}
-* <<write>> {nbsp}
+== Supported Operations
 
-==== Associated Sources
-* <<listener>> {nbsp}
+* <<copy>> 
+* <<createDirectory>> 
+* <<delete>> 
+* <<list>> 
+* <<move>> 
+* <<read>> 
+* <<rename>> 
+* <<write>> 
+
+== Associated Sources
+
+* <<listener>> 
 
 
 == Operations
 
 [[copy]]
 === Copy
+
 `<sftp:copy>`
 
-Copies the file at the sourcePath into the targetPath. If targetPath doesn't exist, and neither does its parent, then an attempt is made to create depending on the value of the createParentFolder argument. If createParentFolder is false, then a SFTP:ILLEGAL_PATH error is thrown.
+Copies the file at the sourcePath into the targetPath.  If targetPath doesn't exist, and neither does its parent, then an attempt is made to create the file depending on the value of the createParentFolder argument. If such an argument occurs, then a SFTP:ILLEGAL_PATH is thrown.
 
-If the target file already exists, then it is overwritten if the overwrite argument is true. Otherwise, a SFTP:FILE_ALREADY_EXISTS error is thrown. As for the sourcePath, it can either be a file or a directory. If it points to a directory, then it is copied recursively.
+If the target file already exists, then it is overwritten if the *Overwrite* field is set to `true`. Otherwise, the SFTP:FILE_ALREADY_EXISTS error is thrown. The source path can be either a file or a directory. If the source path points to a directory, then the file is copied recursively.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Source Path a| String |  +++The path to the file to be copied.+++ |  | *x*{nbsp}
-| Target Path a| String |  +++The target directory where the file is going to be copied.+++ |  | *x*{nbsp}
-| Create Parent Directories a| Boolean |  +++Whether or not to attempt creating any parent directories which don't exist.+++ |  +++true+++ | {nbsp}
-| Overwrite a| Boolean |  +++Whether or not to overwrite the file if the target destination already exists.+++ |  +++false+++ | {nbsp}
-| Rename To a| String |  +++Copied file's new name. If not provided, original file name is kept.+++ |  | {nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Source Path a| String |  The path to the file to be copied. |  | x
+| Target Path a| String |  The target directory where the file is going to be copied. |  | x
+| Create Parent Directories a| Boolean |  Whether or not to attempt creating any parent directories which do not exist. |  true | 
+| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  false | 
+| Rename To a| String |  Copied file's new name. If not provided, the original file name is kept. |  | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
-* SFTP:FILE_ALREADY_EXISTS {nbsp}
+
+* SFTP:CONNECTIVITY 
+* SFTP:FILE_ALREADY_EXISTS 
+* SFTP:ILLEGAL_PATH 
+* SFTP:RETRY_EXHAUSTED 
 
 
 [[createDirectory]]
 === Create Directory
+
 `<sftp:create-directory>`
 
-+++
-Creates a new directory on directoryPath.
-+++
+
+Creates a new directory in the *Directory Path*.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Directory Path a| String |  +++The new directory's name.+++ |  | *x*{nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Directory Path a| String |  The new directory's name. |  | x
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ACCESS_DENIED {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
-* SFTP:FILE_ALREADY_EXISTS {nbsp}
+
+* SFTP:ACCESS_DENIED 
+* SFTP:CONNECTIVITY 
+* SFTP:FILE_ALREADY_EXISTS 
+* SFTP:ILLEGAL_PATH 
+* SFTP:RETRY_EXHAUSTED 
 
 
 [[delete]]
 === Delete
+
 `<sftp:delete>`
 
-+++
-Deletes the file pointed by path, provided that it's not locked
-+++
+
+Deletes the file pointed to by the *Path*, provided that the file is not locked.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Path a| String |  +++The path to the file to be deleted.+++ |  | *x*{nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Path a| String |  The path to the file to be deleted. |  | x
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ACCESS_DENIED {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
+
+* SFTP:ACCESS_DENIED 
+* SFTP:CONNECTIVITY 
+* SFTP:ILLEGAL_PATH 
+* SFTP:RETRY_EXHAUSTED 
 
 
 [[list]]
 === List
+
 `<sftp:list>`
 
-+++
-Lists all the files in the directoryPath that match the given matcher. If the listing encounters a directory, the output list includes its contents depending on the value of the recursive parameter. If recursive is set to true but a found directory is rejected by the matcher, then there isn't any recursion into that directory.
-+++
+
+Lists all the files in the *Directory Path* that match the given matcher.
+
+If the listing encounters a directory, the output list includes its contents depending on the value of the recursive parameter.  If *Recursive* is set to `true` but a found directory is rejected by the matcher, then no recursion occurs into the directory.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Directory Path a| String |  +++The path to the directory to be listed.+++ |  | *x*{nbsp}
-| Recursive a| Boolean |  +++Whether to include the contents of sub-directories. Defaults to false.+++ |  +++false+++ | {nbsp}
-| File Matching Rules a| <<matcher>> |  +++A matcher used to filter the output list.+++ |  | {nbsp}
-| Target Variable a| String |  +++The name of a variable on which the operation's output is placed.+++ |  | {nbsp}
-| Target Value a| String |  +++An expression that is evaluated against the operation's output. The outcome of that expression is stored in the target variable.+++ |  +++#[payload]+++ | {nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Directory Path a| String |  The path to the directory to be listed. |  | x
+| Recursive a| Boolean |  Whether to include the contents of sub-directories. Defaults to false. |  false | 
+| File Matching Rules a| <<matcher>> |  A matcher used to filter the output list. |  | 
+| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to be read. |  | 
+| Time Between Size Check Unit a| Enumeration, one of:
+
+** NANOSECONDS
+** MICROSECONDS
+** MILLISECONDS
+** SECONDS
+** MINUTES
+** HOURS
+** DAYS |  Time unit to use in the wait time between size checks. |  | 
+| Streaming Strategy a| * <<repeatable-in-memory-iterable>>
+* <<repeatable-file-store-iterable>>
+* non-repeatable-iterable |  Configure to use repeatable streams. |  | 
+| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 ==== Output
-[cols=".^50%,.^50%"]
+
+[%autowidth.spread]
 |===
-| *Type* a| Array of Message of [Binary] payload and [<<SftpFileAttributes>>] attributes
+|Type |Array of Message of any payload and <<SftpFileAttributes>> attributes.
 |===
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ACCESS_DENIED {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
+
+* SFTP:ACCESS_DENIED 
+* SFTP:ILLEGAL_PATH 
 
 
 [[move]]
 === Move
+
 `<sftp:move>`
 
-Moves the file at the sourcePath into the targetPath. If targetPath doesn't exist, and neither does its parent, then an attempt is made to create depending on the value of the createParentFolder argument. If createParentFolder is false, then a SFTP:ILLEGAL_PATH error is thrown. If the target file already exists, then it is overwritten if the overwrite argument is true. Otherwise, a SFTP:FILE_ALREADY_EXISTS error is thrown. As for the sourcePath, it can either be a file or a directory. If it points to a directory, then it is moved recursively.
+Moves the file at the *Source Path* into the *Target Path*.
+
+If *Target Path* doesn't exist, and neither does its parent, then an attempt is made to create depending on the value of the *Create Parent Directories* argument. If *Create Parent Directories* is `false`, then SFTP:ILLEGAL_PATH is thrown.
+
+If the target file exists, it is overwritten if  *Overwrite* is `true`. If *Overwrite* is `false`, SFTP:FILE_ALREADY_EXISTS error is thrown.  
+
+The *Source Path* can either be a file or a directory. If a directory, then it is moved recursively.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Source Path a| String |  +++The path to the file to be copied.+++ |  | *x*{nbsp}
-| Target Path a| String |  +++The target directory.+++ |  | *x*{nbsp}
-| Create Parent Directories a| Boolean |  +++Whether or not to attempt creating any parent directories which don't exist.+++ |  +++true+++ | {nbsp}
-| Overwrite a| Boolean |  +++Whether or not to overwrite the file if the target destination already exists.+++ |  +++false+++ | {nbsp}
-| Rename To a| String |  +++Moved file's new name. If not provided, original file name is kept.+++ |  | {nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Source Path a| String |  The path to the file to be copied. |  | x
+| Target Path a| String |  The target directory. |  | x
+| Create Parent Directories a| Boolean |  Whether or not to attempt creating parent directories that don't exist. |  true | 
+| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  false | 
+| Rename To a| String |  The moved file's new name. If not provided, the original file name is kept. |  | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
-* SFTP:FILE_ALREADY_EXISTS {nbsp}
+
+* SFTP:CONNECTIVITY 
+* SFTP:FILE_ALREADY_EXISTS 
+* SFTP:ILLEGAL_PATH 
+* SFTP:RETRY_EXHAUSTED 
 
 
 [[read]]
 === Read
+
 `<sftp:read>`
 
-Obtains the content and metadata of a file at a given path. The operation itself returns a Message whose payload is an InputStream with the file's content, and the metadata is represented as a SftpFileAttributes object that's placed as the message Message#getAttributes() attributes.
+Obtains the content and metadata of a file at a given path. 
 
-If the lock parameter is set to true, then a file system level lock is placed on the file until the input stream this operation returns is closed or fully consumed. Because the lock is actually provided by the host file system, its behavior might change depending on the mounted drive and the operating system on which Mule is running. Take that into consideration before blindly relying on this lock.
+The operation returns a message with a payload that is an InputStream with the file's content, and the metadata is represented as a SftpFileAttributes object that's placed as the message Message#getAttributes() attributes.
 
-This method also makes a best effort to determine the MIME type of the file being read. The file's extension is used to make an educated guess on the file's MIME type. The user also has the chance to force the output encoding and mimeType through the outputEncoding and outputMimeType optional parameters.
+If *Lock* is `true`, then a file system level lock is placed on the file until the input stream this operation returns is closed or fully consumed. Because the lock is actually provided by the host file system, its behavior might change depending on the mounted drive and the operation system on which Mule is running. Consider this before relying on this lock. 
+
+This method also makes a best effort to determine the MIME type of the file being read. The file's extension is used to make an educated guess on the file's MIME type. The user also has the chance to force the output encoding and MIME type through the *Output Mime Type* and *Output Encoding* optional fields.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| File Path a| String |  +++The path to the file to be read.+++ |  | *x*{nbsp}
-| Lock a| Boolean |  +++Whether or not to lock the file. Defaults to false.+++ |  +++false+++ | {nbsp}
-| Output Mime Type a| String |  +++The MIME type of the payload that this operation outputs.+++ |  | {nbsp}
-| Output Encoding a| String |  +++The encoding of the payload that this operation outputs.+++ |  | {nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| File Path a| String |  The path to the file to be read. |  | x
+| Lock a| Boolean |  Whether or not to lock the file. Defaults to false. |  false | 
+| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to be read. |  | 
+| Time Between Size Check Unit a| Enumeration, one of:
+
+** NANOSECONDS
+** MICROSECONDS
+** MILLISECONDS
+** SECONDS
+** MINUTES
+** HOURS
+** DAYS |  Time unit to use in the wait time between size checks. |  | 
+| Output Mime Type a| String |  The MIME type of the payload that this operation outputs. |  | 
+| Output Encoding a| String |  The encoding of the payload that this operation outputs. |  | 
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior.+++ |  | {nbsp}
-| Target Variable a| String |  +++The name of a variable on which the operation's output is placed.+++ |  | {nbsp}
-| Target Value a| String |  +++An expression that is evaluated against the operation's output. The outcome of that expression is stored in the target variable.+++ |  +++#[payload]+++ | {nbsp}
+* non-repeatable-stream |  Configure to use repeatable streams. |  | 
+| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 ==== Output
-[cols=".^50%,.^50%"]
+
+[%autowidth.spread]
 |===
-| *Type* a| Binary
-| *Attributes Type* a| <<SftpFileAttributes>>
+|Type |Binary
+| Attributes Type a| <<SftpFileAttributes>>
 |===
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ACCESS_DENIED {nbsp}
-* SFTP:FILE_LOCK {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
+
+* SFTP:ACCESS_DENIED 
+* SFTP:CONNECTIVITY 
+* SFTP:FILE_LOCK 
+* SFTP:ILLEGAL_PATH 
+* SFTP:RETRY_EXHAUSTED 
 
 
 [[rename]]
 === Rename
+
 `<sftp:rename>`
 
-+++
-Renames the file pointed by path to the name provided on the to parameter. The to argument should not contain any path separator. SFTP:ILLEGAL_PATH is thrown if this precondition is not honored.
-+++
+
+Renames the file pointed to by the Path to the name provided in the *New Name* field. The *New Name* should not contain any path separator. SFTP:ILLEGAL_PATH is thrown if this precondition is not honored.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Path a| String |  +++The path to the file to be renamed.+++ |  | *x*{nbsp}
-| New Name a| String |  +++The file's new name.+++ |  | *x*{nbsp}
-| Overwrite a| Boolean |  +++Whether or not to overwrite the file if the target destination already exists.+++ |  +++false+++ | {nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Path a| String |  The path to the file to be renamed. |  | x
+| New Name a| String |  The file's new name. |  | x
+| Overwrite a| Boolean |  Whether or not overwrite the file if the target destination already exists. |  false | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ACCESS_DENIED {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
-* SFTP:FILE_ALREADY_EXISTS {nbsp}
+
+* SFTP:ACCESS_DENIED 
+* SFTP:CONNECTIVITY 
+* SFTP:FILE_ALREADY_EXISTS 
+* SFTP:ILLEGAL_PATH 
+* SFTP:RETRY_EXHAUSTED 
 
 
 [[write]]
 === Write
+
 `<sftp:write>`
 
-Writes the content into the file pointed by path. If the directory on which the file is attempting to be written doesn't exist, then the operation will either throw an SFTP:ILLEGAL_PATH error or create such folder depending on the value of createParentDirectory.
+Writes the content into the file pointed to by the path.
 
-If the file itself already exists, then the behavior depends on the supplied mode. This operation also supports locking depending on the value of the lock argument, but following the same rules and considerations as described in the read operation.
+If the directory in which the file is attempting to be written doesn't exist, then the operation either throws SFTP:ILLEGAL_PATH error or creates the folder depending on the value of *Create Parent Directories*.  If the file itself already exists, then the behavior depends on the supplied mode.  This operation also provides locking support depending on the value of *Lock*, but follows the same rules and considerations as described in the Read operation.
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Path a| String |  +++The path of the file to be written.+++ |  | *x*{nbsp}
-| Content a| Binary |  +++The content to be written into the file. Defaults to the current Message payload.+++ |  +++#[payload]+++ | {nbsp}
-| Encoding a| String |  +++When content is a String, this attribute specifies the encoding to be used when writing. If not set, then it defaults to FileConnectorConfig#getDefaultWriteEncoding()+++ |  | {nbsp}
-| Create Parent Directories a| Boolean |  +++Whether or not to attempt creating any parent directories which don't exist.+++ |  +++true+++ | {nbsp}
-| Lock a| Boolean |  +++Whether or not to lock the file. Defaults to false.+++ |  +++false+++ | {nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Path a| String |  The path of the file to be written. |  | x
+| Content a| Binary |  The content to be written into the file. Defaults to the current Message payload. |  `#[payload]` | 
+| Encoding a| String |  When content is a String, this attribute specifies the encoding to use when writing. If not set, then it defaults to FileConnectorConfig#getDefaultWriteEncoding(). |  | 
+| Create Parent Directories a| Boolean |  Whether or not to attempt creating any parent directories which don't exists. |  true | 
+| Lock a| Boolean |  Whether or not to lock the file. Defaults to false. |  false | 
 | Write Mode a| Enumeration, one of:
 
 ** OVERWRITE
 ** APPEND
-** CREATE_NEW |  +++A FileWriteMode. Defaults to OVERWRITE.+++ |  +++OVERWRITE+++ | {nbsp}
+** CREATE_NEW |  A FileWriteMode. Defaults to OVERWRITE. |  OVERWRITE | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
 |===
 
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
+
+* <<config>> 
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED {nbsp}
-* SFTP:ILLEGAL_CONTENT {nbsp}
-* SFTP:ACCESS_DENIED {nbsp}
-* SFTP:ILLEGAL_PATH {nbsp}
-* SFTP:CONNECTIVITY {nbsp}
-* SFTP:FILE_ALREADY_EXISTS {nbsp}
+
+* SFTP:ACCESS_DENIED 
+* SFTP:CONNECTIVITY 
+* SFTP:FILE_ALREADY_EXISTS 
+* SFTP:FILE_LOCK
+* SFTP:ILLEGAL_CONTENT 
+* SFTP:ILLEGAL_PATH 
+* SFTP:RETRY_EXHAUSTED 
 
 
 == Sources
 
 [[listener]]
-=== On New File
+=== On New or Updated File
+
 `<sftp:listener>`
 
-Polls a directory looking for files that have been created on it. One message is generated for each file that is found. The key part of this functionality is how to determine that a file is actually new.
 
-Possible polling strategies:
+Polls a directory looking for files that have been created on it. One message is generated for each file that is found. 
 
-* Set the autoDelete parameter to true: This deletes each processed file after it has been processed, causing all files obtained in the next poll to be necessarily new.
-* Set moveToDirectory parameter: This moves each processed file to a different directory after it has been processed, achieving the same effect as autoDelete but without losing the file.
-* Use the watermarkMode parameter: This only picks files that have been created/updated after the last poll was executed.
+The key part of this functionality is determining if a file is actually new: 
 
-A matcher can also be used for additional filtering of files.
+* Set the `autoDelete` parameter to `true` - This deletes each processed file after it has been processed, causing all files obtained in the next poll to be necessarily new.
+* Set `moveToDirectory` parameter - This moves each processed file to a different directory after it has been processed, achieving the same effect as `autoDelete` but without loosing the file.
+* Use the `watermarkMode` parameter to only pick files that have been created or updated after the last poll was executed. A matcher can also be used for additional filtering of files.
+
 
 ==== Parameters
-[cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
+
+[%header%autowidth.spread]
 |===
 | Name | Type | Description | Default Value | Required
-| Configuration | String | The name of the configuration to use. | | *x*{nbsp}
-| Directory a| String |  +++The directory in which polled files are contained.+++ |  | {nbsp}
-| Recursive a| Boolean |  +++Whether or not to also include files contained in sub directories.+++ |  +++true+++ | {nbsp}
-| Matcher a| <<matcher>> |  +++A matcher used to filter events on files which do not meet the matcher's criteria.+++ |  | {nbsp}
-| Watermark Enabled a| Boolean |  +++Controls whether or not to do watermarking, and if so, if the watermark should consider the file's modification or creation timestamps.+++ |  +++false+++ | {nbsp}
-| Output Mime Type a| String |  +++The MIME type of the payload that this operation outputs.+++ |  | {nbsp}
-| Output Encoding a| String |  +++The encoding of the payload that this operation outputs.+++ |  | {nbsp}
-| Primary Node Only a| Boolean |  +++Whether this source should only be executed on the primary node when running in Cluster.+++ |  | {nbsp}
-| Scheduling Strategy a| <<scheduling-strategy>> |  +++Configures the scheduler that triggers the polling.+++ |  | *x*{nbsp}
+| Configuration | String | The name of the configuration to use. | | x
+| Directory a| String |  The directory on which polled files are contained. |  | 
+| Recursive a| Boolean |  Whether or not to also files contained in sub directories. |  true | 
+| Matcher a| <<matcher>> |  A matcher used to filter events on files which do not meet the matcher's criteria. |  | 
+| Watermark Enabled a| Boolean |  Controls whether or not to do watermarking, and if so, if the watermark should consider the file's modification or creation timestamps. |  false | 
+| Time Between Size Check a| Number |  Wait time in milliseconds between size checks to determine if a file is ready to be read. This allows a file write to complete before processing. You can disable this feature by omitting a value. When enabled, Mule performs two size checks waiting the specified time between calls. If both checks return the same value, the file is ready to be read. |  | 
+| Time Between Size Check Unit a| Enumeration, one of:
+
+** NANOSECONDS
+** MICROSECONDS
+** MILLISECONDS
+** SECONDS
+** MINUTES
+** HOURS
+** DAYS |  A TimeUnit which qualifies the #timeBetweenSizeCheck attribute. |  | 
+| Output Mime Type a| String |  The MIME type of the payload that this operation outputs. |  | 
+| Output Encoding a| String |  The encoding of the payload that this operation outputs. |  | 
+| Primary Node Only a| Boolean |  Whether this source should only be executed on the primary node when running in Cluster. |  | 
+| Scheduling Strategy a| scheduling-strategy |  Configures the scheduler that triggers the polling. |  | x
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* non-repeatable-stream |  +++Configure if repeatable streams should be used and their behavior.+++ |  | {nbsp}
-| Redelivery Policy a| <<RedeliveryPolicy>> |  +++Defines a policy for processing the redelivery of the same message.+++ |  | {nbsp}
+* non-repeatable-stream |  Configure to use repeatable streams. |  | 
+| Redelivery Policy a| <<RedeliveryPolicy>> |  Defines a policy for processing the redelivery of the same message. |  | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  +++A retry strategy in case of connectivity errors.+++ |  | {nbsp}
-| Auto Delete a| Boolean |  |  +++false+++ | {nbsp}
-| Move To Directory a| String |  |  | {nbsp}
-| Rename To a| String |  |  | {nbsp}
-| Apply Post Action When Failed a| Boolean |  |  +++true+++ | {nbsp}
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+| Auto Delete a| Boolean |  Whether each file should be deleted after processing or not. |  false | 
+| Move To Directory a| String |  If provided, each processed file is moved to a directory pointed by this path. |  | 
+| Rename To a| String |  This parameter works in tandem with moveToDirectory. Use this parameter to enter the name under which the file should be moved. Do not set this parameter if moveToDirectory hasn't been set as well. |  | 
+| Apply Post Action When Failed a| Boolean |  Whether any of the post actions (autoDelete and moveToDirectory) should also be applied in case the file failed to be processed. If set to false, no failed files are moved nor deleted. |  true | 
 |===
 
 ==== Output
-[cols=".^50%,.^50%"]
+
+[%autowidth.spread]
 |===
-| *Type* a| Binary
-| *Attributes Type* a| <<SftpFileAttributes>>
+|Type |Binary
+| Attributes Type a| <<SftpFileAttributes>>
 |===
 
-==== For Configurations
-* <<config>> {nbsp}
+=== For Configurations
 
-
+* <<config>> 
 
 == Types
+
 [[SftpProxyConfig]]
 === SFTP Proxy Config
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
 | Host a| String |  |  | x
 | Port a| Number |  |  | x
-| Username a| String |  |  |
-| Password a| String |  |  |
+| Username a| String |  |  | 
+| Password a| String |  |  | 
 | Protocol a| Enumeration, one of:
 
 ** HTTP
@@ -455,12 +553,12 @@ A matcher can also be used for additional filtering of files.
 [[Reconnection]]
 === Reconnection
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment will fail if the test doesn't pass after exhausting the associated reconnection strategy. |  |
+| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> | The reconnection strategy to use. |  |
+* <<reconnect-forever>> | The reconnection strategy to use. |  | 
 |===
 
 [[reconnect]]
@@ -487,48 +585,42 @@ A matcher can also be used for additional filtering of files.
 [[PoolingProfile]]
 === Pooling Profile
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Active a| Number | Controls the maximum number of Mule components that can be borrowed from a session at one time. When set to a negative value, there is no limit to the number of components that may be active at one time. When maxActive is exceeded, the pool is said to be exhausted. |  |
-| Max Idle a| Number | Controls the maximum number of Mule components that can sit idle in the pool at any time. When set to a negative value, there is no limit to the number of Mule components that may be idle at one time. |  |
-| Max Wait a| Number | Specifies the number of milliseconds to wait for a pooled component to become available when the pool is exhausted and the exhaustedAction is set to WHEN_EXHAUSTED_WAIT. |  |
-| Min Eviction Millis a| Number | Determines the minimum amount of time an object may sit idle in the pool before it is eligible for eviction. When non-positive, no objects are evicted from the pool due to idle time alone. |  |
-| Eviction Check Interval Millis a| Number | Specifies the number of milliseconds between runs of the object evictor. When non-positive, no object evictor is executed. |  |
+| Max Active a| Number | Controls the maximum number of Mule components that can be borrowed from a session at one time. When set to a negative value, there is no limit to the number of components that may be active at one time. When maxActive is exceeded, the pool is said to be exhausted. |  | 
+| Max Idle a| Number | Controls the maximum number of Mule components that can sit idle in the pool at any time. When set to a negative value, there is no limit to the number of Mule components that may be idle at one time. |  | 
+| Max Wait a| Number | Specifies the number of milliseconds to wait for a pooled component to become available when the pool is exhausted and the exhaustedAction is set to WHEN_EXHAUSTED_WAIT. |  | 
+| Min Eviction Millis a| Number | Determines the minimum amount of time an object may sit idle in the pool before it is eligible for eviction. When non-positive, no objects are evicted from the pool due to idle time alone. |  | 
+| Eviction Check Interval Millis a| Number | Specifies the number of milliseconds between runs of the object evictor. When non-positive, no object evictor is executed. |  | 
 | Exhausted Action a| Enumeration, one of:
 
 ** WHEN_EXHAUSTED_GROW
 ** WHEN_EXHAUSTED_WAIT
-** WHEN_EXHAUSTED_FAIL a| Specifies the behavior of the Mule component pool when the pool is exhausted.
-
-Possible values are:
+** WHEN_EXHAUSTED_FAIL a| Specifies the behavior of the Mule component pool when the pool is exhausted. Possible values are: 
 
 * WHEN_EXHAUSTED_FAIL - Throw a NoSuchElementException.
 * WHEN_EXHAUSTED_WAIT - Block by invoking Object.wait(long) until a new or idle object is available.
-* WHEN_EXHAUSTED_GROW - Create a new Mule instance and return it, essentially making maxActive meaningless.
-
-If a positive maxWait value is supplied, it blocks for at most that many milliseconds, after which a NoSuchElementException is thrown. If maxThreadWait is a negative value, it blocks indefinitely. |  |
+* WHEN_EXHAUSTED_GROW - Create a new Mule instance and return it, essentially making maxActive meaningless. If a positive maxWait value is supplied, it blocks for at most that many milliseconds, after which a NoSuchElementException is thrown. If maxThreadWait is a negative value, it blocks indefinitely. |  | 
 | Initialisation Policy a| Enumeration, one of:
 
 ** INITIALISE_NONE
 ** INITIALISE_ONE
-** INITIALISE_ALL a| Determines how components in a pool should be initialized.
+** INITIALISE_ALL a| Determines how components in a pool should be initialized. The possible values are: 
 
-The possible values are:
-
-* INITIALISE_NONE - Do not load any components into the pool on startup.
-* INITIALISE_ONE - Load an initial component into the pool on startup.
-* INITIALISE_ALL - Load all components into the pool on startup. |  |
-| Disabled a| Boolean | Whether pooling should be disabled. |  |
+* INITIALISE_NONE - Does not load components into the pool on startup.
+* INITIALISE_ONE - Loads one initial component into the pool on startup.
+* INITIALISE_ALL - Loads all components in the pool on startup. |  | 
+| Disabled a| Boolean | Whether pooling should be disabled |  | 
 |===
 
 [[ExpirationPolicy]]
 === Expiration Policy
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Idle Time a| Number | A scalar time value for the maximum amount of time a dynamic configuration instance should be allowed to be idle before it's considered eligible for expiration. |  |
+| Max Idle Time a| Number | A scalar time value for the maximum amount of time a dynamic configuration instance should be allowed to be idle before it's considered eligible for expiration |  | 
 | Time Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -537,94 +629,121 @@ The possible values are:
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS | A time unit that qualifies the maxIdleTime attribute. |  |
+** DAYS | A time unit that qualifies the maxIdleTime attribute. |  | 
 |===
 
 [[SftpFileAttributes]]
-=== Sftp File Attributes
+=== SFTP File Attributes
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Directory a| Boolean |  |  |
-| Name a| String |  |  |
-| Path a| String |  |  |
-| Regular File a| Boolean |  |  |
-| Size a| Number |  |  |
-| Symbolic Link a| Boolean |  |  |
-| Timestamp a| DateTime |  |  |
+| Timestamp a| DateTime |  |  | x
+| Size a| Number |  |  | x
+| Regular Size a| Boolean |  | false | 
+| Directory a| Boolean |  | false | 
+| Symbolic Link a| Boolean |  | false | 
+| Path a| String |  |  | x
+| File Name a| String |  |  | x
 |===
 
 [[matcher]]
 === Matcher
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Timestamp Since a| DateTime |  |  |
-| Timestamp Until a| DateTime |  |  |
-| Filename Pattern a| String |  |  |
-| Path Pattern a| String |  |  |
+| Timestamp Since a| DateTime | Files created before this date are rejected. |  | 
+| Timestamp Until a| DateTime | Files created after this date are rejected. |  | 
+| Filename Pattern a| String |  |  | 
+| Path Pattern a| String |  |  | 
 | Directories a| Enumeration, one of:
 
 ** REQUIRE
 ** INCLUDE
-** EXCLUDE |  | INCLUDE |
+** EXCLUDE |  | INCLUDE | 
 | Regular Files a| Enumeration, one of:
 
 ** REQUIRE
 ** INCLUDE
-** EXCLUDE |  | INCLUDE |
+** EXCLUDE |  | INCLUDE | 
 | Sym Links a| Enumeration, one of:
 
 ** REQUIRE
 ** INCLUDE
-** EXCLUDE |  | INCLUDE |
-| Min Size a| Number |  |  |
-| Max Size a| Number |  |  |
+** EXCLUDE |  | INCLUDE | 
+| Min Size a| Number |  |  | 
+| Max Size a| Number |  |  | 
 |===
 
 [[repeatable-in-memory-stream]]
 === Repeatable In Memory Stream
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Initial Buffer Size a| Number | This is the amount of memory that is allocated in order to consume the stream and provide random access to it. If the stream contains more data than can be fit into this buffer, then it is expanded by according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. |  |
-| Buffer Size Increment a| Number | This is by how much buffer size is expanded if it exceeds its initial size. Setting a value of zero or lower will mean that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised when the buffer gets full. |  |
-| Max Buffer Size a| Number | This is the maximum amount of memory that is used. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower or equal to zero means no limit. |  |
+| Initial Buffer Size a| Number | The amount of memory that is allocated to consume the stream and provide random access to it. If the stream contains more data than can be fit into this buffer, then the buffer expands according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. |  | 
+| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised when the buffer gets full. |  | 
+| Max Buffer Size a| Number | The maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower than or equal to zero means no limit. |  | 
 | Buffer Unit a| Enumeration, one of:
 
 ** BYTE
 ** KB
 ** MB
-** GB | The unit in which all these attributes are expressed |  |
+** GB | The unit in which all these attributes are expressed. |  | 
 |===
 
 [[repeatable-file-store-stream]]
 === Repeatable File Store Stream
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Max In Memory Size a| Number | Defines the maximum memory that the stream should use to keep data in memory. If more than that is consumed then it will start to buffer the content on disk. |  |
+| Max In Memory Size a| Number | Defines the maximum memory that the stream should use to keep data in memory. If more than that is consumed then it will start to buffer the content on disk. |  | 
 | Buffer Unit a| Enumeration, one of:
 
 ** BYTE
 ** KB
 ** MB
-** GB | The unit in which maxInMemorySize is expressed |  |
+** GB | The unit in which maxInMemorySize is expressed |  | 
 |===
 
 [[RedeliveryPolicy]]
 === Redelivery Policy
 
-[cols=".^20%,.^25%,.^30%,.^15%,.^10%", options="header"]
+[%header%autowidth.spread]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Redelivery Count a| Number | The maximum number of times a message can be redelivered and processed unsuccessfully before triggering process-failed-message. |  |
-| Use Secure Hash a| Boolean | Whether to use a secure hash algorithm to identify a redelivered message. |  |
-| Message Digest Algorithm a| String | The secure hashing algorithm to use. If not set, the default is SHA-256. |  |
-| Id Expression a| String | Defines one or more expressions to use to determine when a message has been redelivered. This property may only be set if useSecureHash is false. |  |
-| Object Store a| ObjectStore | The object store where the redelivery counter for each message is going to be stored. |  |
+| Max Redelivery Count a| Number | The maximum number of times a message can be redelivered and processed unsuccessfully before triggering process-failed-message. |  | 
+| Use Secure Hash a| Boolean | Whether to use a secure hash algorithm to identify a redelivered message. |  | 
+| Message Digest Algorithm a| String | The secure hashing algorithm to use. If not set, the default is SHA-256. |  | 
+| Id Expression a| String | Defines one or more expressions to use to determine when a message has been redelivered. This property may only be set if useSecureHash is false. |  | 
+| Object Store a| Object Store | The object store where the redelivery counter for each message is going to be stored. |  | 
 |===
+
+[[repeatable-in-memory-iterable]]
+=== Repeatable In Memory Iterable
+
+[%header%autowidth.spread]
+|===
+| Field | Type | Description | Default Value | Required
+| Initial Buffer Size a| Number | The number of instances to initially keep in memory to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then the buffer expands according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. Default value is 100 instances. |  | 
+| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised when the buffer gets full. Default value is 100 instances. |  | 
+| Max Buffer Size a| Number | The maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower than or equal to zero means no limit. |  | 
+|===
+
+[[repeatable-file-store-iterable]]
+=== Repeatable File Store Iterable
+
+[%header%autowidth.spread]
+|===
+| Field | Type | Description | Default Value | Required
+| Max In Memory Size a| Number | The maximum amount of instances to keep in memory. If more than that is required, then it starts to buffer the content on disk. |  | 
+| Buffer Unit a| Enumeration, one of:
+
+** BYTE
+** KB
+** MB
+** GB | The unit in which maxInMemorySize is expressed. |  | 
+|===
+


### PR DESCRIPTION
Updated the SFTP Connector Reference to the latest version. The previous version was at least a year out of date. This new version is current to SFTP Connector v1.2.5.
Provides fixes for DOCS-5317 and DOCS-5168.