### PR TITLE
Add vm:consume to an example and fix nav file.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -259,7 +259,7 @@
 * xref:validation/validation-connector.adoc[Validation Module]
  ** xref:validation/validation-documentation.adoc[Validation Connector Reference]
 * xref:vm/vm-connector.adoc[VM Connector]
- ** xref:vm/vm-publish-listen.adoc[Example: Publish and Get a Response in the VM Connector]]
+ ** xref:vm/vm-publish-listen.adoc[Example: Publish and Listen to Messages with the VM Connector]]
  ** xref:vm/vm-dynamic-routing.adoc[Example: Dynamic Routing with the VM Connector]
  ** xref:vm/vm-publish-response.adoc[Example: Publish and Get a Response in the VM Connector]
  ** xref:vm/vm-publish-across-apps.adoc[Example: Send Messages across Different Apps]

--- a/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
+++ b/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
@@ -22,23 +22,13 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
              xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-               http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
+             http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
 
-    <vm:config name="sharedVMConfig">
-      <vm:queue queueName="sharedQueue" queueType="PERSISTENT" />
-    </vm:config>
+  <vm:config name="sharedVMConfig">
+    <vm:queue queueName="sharedQueue" queueType="PERSISTENT" />
+  </vm:config>
 
 </mule-domain>
-----
-+
-. Place a listener in an application of the same domain:
-+
-[source,xml,linenums]
-----
-<flow name="crossAppListener">
-	<vm:listener queueName="sharedQueue" config-ref="sharedVMConfig" />
-	<logger />
-</flow>
 ----
 +
 . Publish messages from a second application, also of the same domain:
@@ -46,7 +36,7 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
 [source,xml,linenums]
 ----
 <flow name="crossAppRequester">
-	<vm:publish queueName="sharedQueue" config-ref="sharedVMConfig" />
+  <vm:publish queueName="sharedQueue" config-ref="sharedVMConfig" />
 </flow>
 ----
 +
@@ -55,9 +45,9 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
 [source,xml,linenums]
 ----
 <flow name="queueConsume">
-    <vm:consume queueName="myQueue" config-ref="sharedVMConfig" />
-    <logger />
+  <vm:consume queueName="myQueue" config-ref="sharedVMConfig" />
+  <logger />
 </flow>
 ----
 +
-In this example, the `listener`, `publish`, and `consume` operations point to the configuration defined in the domain.
+In this example, the `publish` and `consume` operations point to the configuration defined in mule-domain.

--- a/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
+++ b/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
@@ -19,10 +19,10 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
 [source,xml,linenums]
 ----
 <mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
-             xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-             http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
+  xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+  http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
 
   <vm:config name="sharedVMConfig">
     <vm:queue queueName="sharedQueue" queueType="PERSISTENT" />
@@ -50,4 +50,4 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
 </flow>
 ----
 +
-In this example, the `publish` and `consume` operations point to the configuration defined in mule-domain.
+In this example, the `publish` and `consume` operations point to the configuration defined in `mule-domain`.

--- a/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
+++ b/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
@@ -45,7 +45,7 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
 [source,xml,linenums]
 ----
 <flow name="queueConsume">
-  <vm:consume queueName="myQueue" config-ref="sharedVMConfig" />
+  <vm:consume queueName="sharedQueue" config-ref="sharedVMConfig" />
   <logger />
 </flow>
 ----

--- a/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
+++ b/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
@@ -5,9 +5,6 @@ endif::[]
 :keywords: VM, queues, connector, publish, listen, response, domain, across applications
 
 
-
-
-
 Instead of using the `<vm:listener>` message source, you can consume messages in a VM queue through the `<vm:consume>` operation.
 
 This operation can consume messages on demand, allowing you to:
@@ -15,10 +12,10 @@ This operation can consume messages on demand, allowing you to:
 * Dynamically consume from different queues depending on a certain condition.
 * Have a tighter control on the rhythm at which the app consumes messages.
 
-You can also send messages across apps by using Mule domains. Unlike Mule 3.x in which domains were reserved to a handful of supported components, starting in Mule 4, every connector can be placed in a domain.
+You can also send messages across apps by using Mule domains. Starting in Mule 4, every connector can be placed in a domain. If you create the VM configuration in a domain, all apps in that domain can use the same configuration.
 
-So, you can create a VM configuration in a domain like in this:
-
+. Create a VM configuration in a domain like in this:
++
 [source,xml,linenums]
 ----
 <mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
@@ -33,9 +30,9 @@ So, you can create a VM configuration in a domain like in this:
 
 </mule-domain>
 ----
-
-Then you place a listener in an application of the same domain:
-
++
+. Place a listener in an application of the same domain:
++
 [source,xml,linenums]
 ----
 <flow name="crossAppListener">
@@ -43,14 +40,24 @@ Then you place a listener in an application of the same domain:
 	<logger />
 </flow>
 ----
-
-Then you publish messages from a second application, also of the same domain:
-
++
+. Publish messages from a second application, also of the same domain:
++
 [source,xml,linenums]
 ----
 <flow name="crossAppRequester">
 	<vm:publish queueName="sharedQueue" config-ref="sharedVMConfig" />
 </flow>
 ----
-
-Notice how both the listener and publisher point to the same configuration defined in the domain.
++
+. Pull messages from the queue after they are published.
++
+[source,xml,linenums]
+----
+<flow name="queueConsume">
+    <vm:consume queueName="myQueue" config-ref="sharedVMConfig" />
+    <logger />
+</flow>
+----
++
+In this example, the `listener`, `publish`, and `consume` operations point to the configuration defined in the domain.

--- a/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
+++ b/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
@@ -4,17 +4,63 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: VM, queues, connector, publish, listen, response, domain, across applications
 
+The following examples show two ways to send messages across different apps:
 
-Instead of using the `<vm:listener>` message source, you can consume messages in a VM queue through the `<vm:consume>` operation.
+* Use a listener to receive the messages from the first app and a `publish` operation to feed the received messages to a second app.
+* Use a `publish` operation in a second app to pull messages from the queue of messages, and a `consume` operation to consume the messages.
 
-This operation can consume messages on demand, allowing you to:
+In both cases, the two apps must be in the same domain.
+
+== Publishing Messages to a Second App
+
+To publish messages to a second app:
+
+. Create a VM configuration in a domain, like this:
++
+[source,xml,linenums]
+----
+<mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
+  xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+  http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
+  <vm:config name="sharedVMConfig">
+    <vm:queue queueName="sharedQueue" queueType="PERSISTENT" />
+  </vm:config>
+</mule-domain>
+----
++
+. Place a listener in an app in the same domain:
++
+[source,xml,linenums]
+----
+<flow name="crossAppListener">
+	<vm:listener queueName="sharedQueue" config-ref="sharedVMConfig" />
+	<logger />
+</flow>
+----
++
+. Publish messages from a second app in the same domain:
++
+[source,xml,linenums]
+----
+<flow name="crossAppRequester">
+  <vm:publish queueName="sharedQueue" config-ref="sharedVMConfig" />
+</flow>
+----
+
+In this example, the listener and `publish` operation point to the same queue (`sharedQueue`) and the same configuration (`sharedVMConfig`).
+
+== Pull Published Messages from a Queue
+
+Instead of using the `<vm:listener>` message source, you can consume messages in a VM queue through the `<vm:consume>` operation. This operation can consume messages on demand, allowing you to:
 
 * Dynamically consume from different queues depending on a certain condition.
 * Have a tighter control on the rhythm at which the app consumes messages.
 
-You can also send messages across apps by using Mule domains. Starting in Mule 4, every connector can be placed in a domain. If you create the VM configuration in a domain, all apps in that domain can use the same configuration.
+To consume published messages from a queue:
 
-. Create a VM configuration in a domain like in this:
+. Create a VM configuration in a domain, like this:
 +
 [source,xml,linenums]
 ----
@@ -31,7 +77,7 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
 </mule-domain>
 ----
 +
-. Publish messages from a second application, also of the same domain:
+. Publish messages from a second app in the same domain:
 +
 [source,xml,linenums]
 ----
@@ -49,5 +95,5 @@ You can also send messages across apps by using Mule domains. Starting in Mule 4
   <logger />
 </flow>
 ----
-+
-In this example, the `publish` and `consume` operations point to the configuration defined in `mule-domain`.
+
+In this example, the `publish` and `consume` operations point to the same queue (`sharedQueue`) and the same configuration (`sharedVMConfig`).

--- a/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
+++ b/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
@@ -6,14 +6,12 @@ endif::[]
 
 The following examples show two ways to send messages across different apps:
 
-* Use a listener to receive the messages from the first app and a `publish` operation to feed the received messages to a second app.
-* Use a `publish` operation in a second app to push messages to the queue of messages, and a `consume` operation to consume the messages.
+* Use a Listener to receive the messages from the first app and a Publish operation to feed the received messages to a second app.
+* Use a Publish operation in a second app to push messages to the queue of messages, and a Consume operation to consume the messages.
 
 In both cases, the two apps must be in the same domain.
 
-== Publishing Messages to a Second App
-
-To publish messages to a second app:
+== Publish Messages to a Second App
 
 . Create a VM configuration in a domain, like this:
 +
@@ -22,8 +20,10 @@ To publish messages to a second app:
 <mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
   xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-  http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm
+  http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+  http://www.mulesoft.org/schema/mule/domain
+  http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
   <vm:config name="sharedVMConfig">
     <vm:queue queueName="sharedQueue" queueType="PERSISTENT" />
   </vm:config>
@@ -49,7 +49,7 @@ To publish messages to a second app:
 </flow>
 ----
 
-In this example, the listener and `publish` operation point to the same queue (`sharedQueue`) and the same configuration (`sharedVMConfig`).
+In this example, the Listener and Publish operation point to the same queue (`sharedQueue`) and the same configuration (`sharedVMConfig`).
 
 == Pull Published Messages from a Queue
 
@@ -67,8 +67,10 @@ To consume published messages from a queue:
 <mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
   xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-  http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm
+  http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+  http://www.mulesoft.org/schema/mule/domain
+  http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
 
   <vm:config name="sharedVMConfig">
     <vm:queue queueName="sharedQueue" queueType="PERSISTENT" />
@@ -96,4 +98,4 @@ To consume published messages from a queue:
 </flow>
 ----
 
-In this example, the `publish` and `consume` operations point to the same queue (`sharedQueue`) and the same configuration (`sharedVMConfig`).
+In this example, the Publish and Consume operations point to the same queue (`sharedQueue`) and the same configuration (`sharedVMConfig`).

--- a/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
+++ b/modules/ROOT/pages/vm/vm-publish-across-apps.adoc
@@ -7,7 +7,7 @@ endif::[]
 The following examples show two ways to send messages across different apps:
 
 * Use a listener to receive the messages from the first app and a `publish` operation to feed the received messages to a second app.
-* Use a `publish` operation in a second app to pull messages from the queue of messages, and a `consume` operation to consume the messages.
+* Use a `publish` operation in a second app to push messages to the queue of messages, and a `consume` operation to consume the messages.
 
 In both cases, the two apps must be in the same domain.
 


### PR DESCRIPTION
I have added a vm:consume operation to the example, but I know the example does not match the description because it has a Listener operation in it. Please let me know how to update the description or the example so they are both correct.