### PR TITLE
Docs 6178 move as2 here mc

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -45,6 +45,7 @@
     *** xref:anypoint-mq/2.x/anypoint-mq-consume.adoc[Anypoint MQ Consume Operation]
     *** xref:anypoint-mq/2.x/anypoint-mq-publish.adoc[Anypoint MQ Publish Operation]
     *** xref:anypoint-mq/2.x/anypoint-mq-connector-reference.adoc[Anypoint MQ Connector Reference]
+* xref:as2/as2-connector.adoc[AS2 Connector]
 * xref:blend/blend-connector.adoc[Blend Connector]
 ** xref:blend/blend-connector-reference.adoc[Blend Connector Reference]
 * xref:bmc/bmc-remedy-connector.adoc[BMC Remedy Connector]

--- a/modules/ROOT/pages/as2/as2-connector.adoc
+++ b/modules/ROOT/pages/as2/as2-connector.adoc
@@ -16,6 +16,8 @@ This document assumes that you are familiar with AS2, Mule, Anypoint Connectors,
 
 For hardware and software requirements, see the Connector Release Notes.
 
+NOTE: This connector requires http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java Cryptography Extension (JCE)] installed on your Java runtime.
+
 
 == How to Install
 
@@ -23,8 +25,6 @@ For hardware and software requirements, see the Connector Release Notes.
 . Click Login in Anypoint Exchange and supply your Anypoint Platform username and password.
 . Search for the connector and click Install.
 . Follow the prompts to install the connector.
-
-NOTE :This connector requires http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java Cryptography Extension (JCE)] installed on your Java runtime.
 
 == About the Connector Namespace and Schema
 
@@ -57,7 +57,7 @@ xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
 NOTE: Use `current` in the schema path to use the current Mule version.
 
 
-== To Configure the Connector Global Element
+== Configure the Connector Global Element
 
 Place the connector in your flow as applicable for your use case.
 
@@ -96,35 +96,33 @@ To use the AS2 connector in your Mule application, create a global AS2 element f
 |MDN Receiver Module Ports - Secure Receiver Keystore Password|The password of the keystore.
 |===
 
-
-
 == Operations
 
 . Send: Sends a message through HTTP or HTTPS using the AS2 protocol.
 . Receive: Source that receives messages via HTTP or HTTPS using the AS2 protocol.
 
-== Using the Connector
+// == Using the Connector
 
-* <<use-case-1,Working example of send use case>>
-* <<use-case-2,Working example of receive source use case>>
+// * <<use-case-1,Working example of send use case>>
+// * <<use-case-2,Working example of receive source use case>>
 
-To configure the connector you have to complete the connector's global element properties with the required elements as described above.
+// To configure the connector you have to complete the connector's global element properties with the required elements as // described above.
 
-image::as2-global-element-properties.png[AS2 Global Element Properties]
+// image::as2-global-element-properties.png[AS2 Global Element Properties]
 
-You can set placeholders in each property and define them in the `mule-app.properties` file.
+// You can set placeholders in each property and define them in the `mule-app.properties` file.
 
-[use-case-1]
-== Example of a Send Use Case
+// [use-case-1]
+// == Example of a Send Use Case
 
-image::as2-use-case-1-flow.png[AS2 Use Case 1 flow]
+// image::as2-use-case-1-flow.png[AS2 Use Case 1 flow]
 
-NOTE: It is not possible to specify both receiver and secured receiver module ports.
+// NOTE: It is not possible to specify both receiver and secured receiver module ports.
 
-[use-case-2]
-== Example of a Receive Source Use Case
+// [use-case-2]
+// == Example of a Receive Source Use Case
 
-image::as2-use-case-2-flow.png[AS2 Use Case 2 flow]
+// image::as2-use-case-2-flow.png[AS2 Use Case 2 flow]
 
 
 == See Also

--- a/modules/ROOT/pages/as2/as2-connector.adoc
+++ b/modules/ROOT/pages/as2/as2-connector.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 Support Category: Premium
 
-The Mule Runtime supports the AS2 protocol through the AS2 Connector. The AS2 connector enables trading partners transmit and receive AS2 messages with EDI-X12, EDIFACT, XML or binary payloads.
+Mule supports the AS2 protocol through the AS2 Connector. The AS2 connector enables trading partners to transmit and receive AS2 messages with EDI-X12, EDIFACT, XML or binary payloads.
 
 This connector leverages the AS2 protocol, allowing Mule applications to:
 

--- a/modules/ROOT/pages/as2/as2-connector.adoc
+++ b/modules/ROOT/pages/as2/as2-connector.adoc
@@ -112,7 +112,7 @@ To configure the connector you have to complete the connector's global element p
 
 image::as2-global-element-properties.png[AS2 Global Element Properties]
 
-You can set placeholders in each property and define them in the mule-app.properties file.
+You can set placeholders in each property and define them in the `mule-app.properties` file.
 
 [use-case-1]
 == Example of a Send Use Case

--- a/modules/ROOT/pages/as2/as2-connector.adoc
+++ b/modules/ROOT/pages/as2/as2-connector.adoc
@@ -54,7 +54,7 @@ xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
 </mule>
 ----
 
-NOTE: Use `current` in the schema path. Studio interprets this to the current Mule version.
+NOTE: Use `current` in the schema path to use the current Mule version.
 
 
 == To Configure the Connector Global Element

--- a/modules/ROOT/pages/as2/as2-connector.adoc
+++ b/modules/ROOT/pages/as2/as2-connector.adoc
@@ -1,0 +1,134 @@
+= AS2 Connector
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+
+Support Category: Premium
+
+The Mule Runtime supports the AS2 protocol through the AS2 Connector. The AS2 connector enables trading partners transmit and receive AS2 messages with EDI-X12, EDIFACT, XML or binary payloads.
+
+This connector leverages the AS2 protocol, allowing Mule applications to:
+
+* Send messages, signed or unsigned, over HTTP or HTTPS, following the AS2 protocol.
+* Receive messages, also over HTTP or HTTPS, following the protocol.
+
+This document assumes that you are familiar with AS2, Mule, Anypoint Connectors, and Anypoint Studio.
+
+For hardware and software requirements, see the Connector Release Notes.
+
+[[install]]
+== How to Install
+
+. In Anypoint Studio, click the Exchange icon in the Studio task bar.
+. Click Login in Anypoint Exchange and supply your Anypoint Platform username and password.
+. Search for the connector and click Install.
+. Follow the prompts to install the connector.
+
+[NOTE]
+This connector requires http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java Cryptography Extension (JCE)] installed on your Java runtime.
+
+== About the Connector Namespace and Schema
+
+In Anypoint Studio, when you drag the connector from the palette onto the Anypoint Studio canvas, Studio automatically populates the XML code with the connector namespace and schema location.
+
+Namespace: `+http://www.mulesoft.org/schema/mule/as2+` +
+Schema Location `+http://www.mulesoft.org/schema/mule/as2/current/mule-as2.xsd+`
+
+If you are manually coding the Mule application in Studio's XML editor or another text editor, define the namespace and schema location in the header of your Configuration XML, inside the `<mule>` tag.
+
+[source,xml,linenums]
+----
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http"
+xmlns:as2="http://www.mulesoft.org/schema/mule/as2"
+xmlns="http://www.mulesoft.org/schema/mule/core"
+xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:spring="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xsi:schemaLocation="http://www.springframework.org/schema/beans
+	    http://www.springframework.org/schema/beans/spring-beans-current.xsd
+        http://www.mulesoft.org/schema/mule/core
+	http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/as2
+	http://www.mulesoft.org/schema/mule/as2/current/mule-as2.xsd">
+      <!-- put your global configuration elements and flows here -->
+
+</mule>
+----
+
+*Note:* Use `current` in the schema path. Studio interprets this to the current Mule version.
+
+[[configure]]
+== To Configure the Connector Global Element
+
+Place the connector in your flow as applicable for your use case.
+
+To use the AS2 connector in your Mule application, create a global AS2 element for use by the AS2 connector. The AS2 connector provides the following global configuration parameters:
+
+[%header%autowidth.spread]
+|===
+|Key| Description
+|Partner From - Name| Sender partner's name.
+|Partner From - AS2 id| Sender partner's ID.
+|Partner From - x509 alias| Sender alias as defined in the certificate file.
+|Partner From - Email| Sender partner's email.
+|Partner To - Name| Receiver partner's name.
+|Partner To - AS2 id| Receiver partner's ID.
+|Partner To - x509 alias| Receiver alias as defined in the certificate.
+|Partner To - Email| Receiver partner's email.
+|Partnership - Sender| The sender's name.
+|Partnership - Receiver| The receiver's name.
+|Partnership - Subject| The text used in email subject line.
+|Partnership - AS2 URL| The partners AS2 server's URL.
+|Partnership - AS2 Receipt Option| The URL that the partner sends the MDN.
+|Partnership - Encrypt| The encryption algorithm for email header.
+|Partnership - Sign|The sign encryption of the message. None by default (message is not signed).
+|Partnership - Content transfer encoding|The content transfer encoding. *Binary* by default.
+|Partnership - Compression type|The compression type. ZLIB is the only supported compression/decompression. Disabled by default.
+|Partnership - Remove CMS algorithm protection attrib|Disable the OID from being sent.
+|AS2 Keystore - Keystore Path|The path of the keystore.
+|AS2 Keystore - Keystore Password|The password of the keystore.
+|Receive Module Ports - Receiver Port|The port used by the receive source.
+|Receive Module Ports - Secure Receiver Port|The secure port (SSL) used by the receive source.
+|Receive Module Ports - Secure Receiver Keystore Path|The path of the keystore with the SSL certificate for the receiver source.
+|Receive Module Ports - Secure Receiver Keystore Password|The password of the keystore.
+|MDN Receiver Module Ports - Receiver Port|The port for the MDN receiver.
+|MDN Receiver Module Ports - Secure Receiver Port|The secure port (SSL) for the MDN receiver.
+|MDN Receiver Module Ports - Secure Receiver Keystore Path|The path of the keystore with the SSL certificate for the MDN receiver.
+|MDN Receiver Module Ports - Secure Receiver Keystore Password|The password of the keystore.
+|===
+
+
+[[operations]]
+== Operations
+
+. Send: Sends a message through HTTP or HTTPS using the AS2 protocol.
+. Receive: Source that receives messages via HTTP or HTTPS using the AS2 protocol.
+
+== Using the Connector
+
+* <<use-case-1,Working example of send use case>>
+* <<use-case-2,Working example of receive source use case>>
+
+To configure the connector you have to complete the connector's global element properties with the required elements as described above.
+
+image::as2-global-element-properties.png[AS2 Global Element Properties]
+
+You can set placeholders in each property and define them in the mule-app.properties file.
+
+[use-case-1]
+== Example of a Send Use Case
+
+image::as2-use-case-1-flow.png[AS2 Use Case 1 flow]
+
+NOTE: It is not possible to specify both receiver and secured receiver module ports.
+
+[use-case-2]
+== Example of a Receive Source Use Case
+
+image::as2-use-case-2-flow.png[AS2 Use Case 2 flow]
+
+
+== See Also
+
+* Access the xref:release-notes::connector/as2-connector-release-notes.adoc[AS2 Connector Release Notes]
+* See https://forums.mulesoft.com/search.html?q=AS2+connector[MuleSoft Forum for this connector]

--- a/modules/ROOT/pages/as2/as2-connector.adoc
+++ b/modules/ROOT/pages/as2/as2-connector.adoc
@@ -16,7 +16,7 @@ This document assumes that you are familiar with AS2, Mule, Anypoint Connectors,
 
 For hardware and software requirements, see the Connector Release Notes.
 
-[[install]]
+
 == How to Install
 
 . In Anypoint Studio, click the Exchange icon in the Studio task bar.
@@ -24,8 +24,7 @@ For hardware and software requirements, see the Connector Release Notes.
 . Search for the connector and click Install.
 . Follow the prompts to install the connector.
 
-[NOTE]
-This connector requires http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java Cryptography Extension (JCE)] installed on your Java runtime.
+NOTE :This connector requires http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java Cryptography Extension (JCE)] installed on your Java runtime.
 
 == About the Connector Namespace and Schema
 
@@ -55,9 +54,9 @@ xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
 </mule>
 ----
 
-*Note:* Use `current` in the schema path. Studio interprets this to the current Mule version.
+NOTE: Use `current` in the schema path. Studio interprets this to the current Mule version.
 
-[[configure]]
+
 == To Configure the Connector Global Element
 
 Place the connector in your flow as applicable for your use case.
@@ -98,7 +97,7 @@ To use the AS2 connector in your Mule application, create a global AS2 element f
 |===
 
 
-[[operations]]
+
 == Operations
 
 . Send: Sends a message through HTTP or HTTPS using the AS2 protocol.


### PR DESCRIPTION
Adding the AS2 connector guide to the connectors directory. This includes adding a folder (as2) and moving the connector file into this directory. It also includes adding the filename to the nav.adoc. The work for removing the connector from PM is in another PR.