### PR TITLE
Fix broken page-aliases

### DIFF
--- a/modules/ROOT/pages/db/database-documentation.adoc
+++ b/modules/ROOT/pages/db/database-documentation.adoc
@@ -3,6 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../../assets/images
+:page-aliases: database/database-documentation.adoc
 
 The Anypoint Database Connector allows you to connect to relational databases through the JDBC API.
 
@@ -18,14 +19,14 @@ The Anypoint Database Connector allows you to connect to relational databases th
 |===
 | Name | Type | Description | Default Value | Required
 |Name | String | The name for this configuration. Connectors reference the configuration with this name. | | x
-| Connection a| * <<config_data-source, Data Source Reference Connection>> 
-* <<config_derby, Derby Connection>> 
-* <<config_generic, Generic Connection>> 
-* <<config_mssql, Microsoft SQL Server Connection>> 
-* <<config_my-sql, MySQL Connection>> 
-* <<config_oracle, Oracle Connection>> 
+| Connection a| * <<config_data-source, Data Source Reference Connection>>
+* <<config_derby, Derby Connection>>
+* <<config_generic, Generic Connection>>
+* <<config_mssql, Microsoft SQL Server Connection>>
+* <<config_my-sql, MySQL Connection>>
+* <<config_oracle, Oracle Connection>>
  | The connection types to provide to this configuration. | | x
-| Expiration Policy a| <<ExpirationPolicy>> |  Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform expires the instance at the exact moment that it becomes eligible. The runtime purges the instances when appropriate. |  | 
+| Expiration Policy a| <<ExpirationPolicy>> |  Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform expires the instance at the exact moment that it becomes eligible. The runtime purges the instances when appropriate. |  |
 |===
 
 ==== Connection Types
@@ -40,10 +41,10 @@ Connection provider implementation which creates database connections from a ref
 [%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
-| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  | 
-| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  | 
+| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  |
+| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  |
 | Data Source Ref a| Any |  Reference to a JDBC DataSource object. This object is typically created using Spring. When using XA transactions, an XADataSource object must be provided. |  | x
-| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
+| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
 |===
 [[config_derby]]
 ===== Derby Connection
@@ -56,8 +57,8 @@ Creates connections to a Derby database
 [%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
-| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  | 
-| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  | 
+| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  |
+| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  |
 | Transaction Isolation a| Enumeration, one of:
 
 ** NONE
@@ -65,13 +66,13 @@ Creates connections to a Derby database
 ** READ_UNCOMMITTED
 ** REPEATABLE_READ
 ** SERIALIZABLE
-** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED | 
-| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false | 
-| Database a| String |  Name of the database. |  | 
-| Subsub Protocol a| String |  Specifies the type of *Subsub protocol* to use by Derby. The available options are: `directory`, `memory`, `classpath` and `jar`. |  directory | 
-| Create a| Boolean |  Indicates if the database should be created if it does not exist. |  false | 
-| Connection Properties a| Object |  Specifies a list of custom key-value connectionProperties for the config. |  | 
-| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
+** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED |
+| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false |
+| Database a| String |  Name of the database. |  |
+| Subsub Protocol a| String |  Specifies the type of *Subsub protocol* to use by Derby. The available options are: `directory`, `memory`, `classpath` and `jar`. |  directory |
+| Create a| Boolean |  Indicates if the database should be created if it does not exist. |  false |
+| Connection Properties a| Object |  Specifies a list of custom key-value connectionProperties for the config. |  |
+| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
 |===
 
 [[config_generic]]
@@ -85,8 +86,8 @@ Connection provider that creates connections for any kind of database using a JD
 [%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
-| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  | 
-| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  | 
+| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  |
+| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  |
 | Transaction Isolation a| Enumeration, one of:
 
 ** NONE
@@ -94,13 +95,13 @@ Connection provider that creates connections for any kind of database using a JD
 ** READ_UNCOMMITTED
 ** REPEATABLE_READ
 ** SERIALIZABLE
-** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED | 
-| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false | 
+** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED |
+| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false |
 | URL a| String |  JDBC URL to use to connect to the database. |  | x
 | Driver Class Name a| String |  Fully-qualified name of the database driver class. |  | x
-| User a| String |  Database username. |  | 
-| Password a| String |  Database password. |  | 
-| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
+| User a| String |  Database username. |  |
+| Password a| String |  Database password. |  |
+| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
 |===
 [[config_mssql]]
 ===== Microsoft SQL Server Connection
@@ -113,8 +114,8 @@ Database connection provider implementation for Microsoft SQL Server databases.
 [%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
-| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  | 
-| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  | 
+| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  |
+| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types. |  |
 | Transaction Isolation a| Enumeration, one of:
 
 ** NONE
@@ -122,15 +123,15 @@ Database connection provider implementation for Microsoft SQL Server databases.
 ** READ_UNCOMMITTED
 ** REPEATABLE_READ
 ** SERIALIZABLE
-** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED | 
-| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false | 
+** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED |
+| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false |
 | Host a| String |  Configures the host of the database. |  | x
-| Port a| Number |  Configures the port of the database. |  1433 | 
-| User a| String |  The user to use for authentication against the database. |  | 
-| Password a| String |  The password to use for authentication against the database. |  | 
-| Database Name a| String |  Name of the default database to work with. |  | 
-| Connection Properties a| Object |  Specifies a list of custom key-value *Connection properties* for the config. |  | 
-| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
+| Port a| Number |  Configures the port of the database. |  1433 |
+| User a| String |  The user to use for authentication against the database. |  |
+| Password a| String |  The password to use for authentication against the database. |  |
+| Database Name a| String |  Name of the default database to work with. |  |
+| Connection Properties a| Object |  Specifies a list of custom key-value *Connection properties* for the config. |  |
+| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
 |===
 
 [[config_my-sql]]
@@ -143,8 +144,8 @@ Creates connections to a MySQL database.
 [%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
-| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  | 
-| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types |  | 
+| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  |
+| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types |  |
 | Transaction Isolation a| Enumeration, one of:
 
 ** NONE
@@ -152,15 +153,15 @@ Creates connections to a MySQL database.
 ** READ_UNCOMMITTED
 ** REPEATABLE_READ
 ** SERIALIZABLE
-** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED | 
-| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false | 
+** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED |
+| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false |
 | Host a| String |  Configures the host of the database |  | x
 | Port a| Number |  Configures the port of the database |  | x
-| User a| String |  The user that is used for authentication against the database |  | 
-| Password a| String |  The password that is used for authentication against the database |  | 
-| Database a| String |  The name of the database |  | 
-| Connection Properties a| Object |  Specifies a list of custom key-value connectionProperties for the config. |  | 
-| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy |  | 
+| User a| String |  The user that is used for authentication against the database |  |
+| Password a| String |  The password that is used for authentication against the database |  |
+| Database a| String |  The name of the database |  |
+| Connection Properties a| Object |  Specifies a list of custom key-value connectionProperties for the config. |  |
+| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy |  |
 |===
 
 [[config_oracle]]
@@ -173,8 +174,8 @@ Creates connections to a Oracle database.
 [%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
-| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  | 
-| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types |  | 
+| Pooling Profile a| <<pooling-profile>> |  Provides a way to configure database connection pooling. |  |
+| Column Types a| Array of <<ColumnType>> |  Specifies non-standard column types |  |
 | Transaction Isolation a| Enumeration, one of:
 
 ** NONE
@@ -182,31 +183,31 @@ Creates connections to a Oracle database.
 ** READ_UNCOMMITTED
 ** REPEATABLE_READ
 ** SERIALIZABLE
-** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED | 
-| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false | 
+** NOT_CONFIGURED |  The transaction isolation level to set on the driver when connecting the database. |  NOT_CONFIGURED |
+| Use XA Transactions a| Boolean |  Indicates whether or not the created datasource has to support XA transactions. Default is false. |  false |
 | Host a| String |  Configures the host of the database |  | x
-| Port a| Number |  Configures the port of the database |  1521 | 
-| User a| String |  The user that is used for authentication against the database |  | 
-| Password a| String |  The password that is used for authentication against the database |  | 
-| Instance a| String |  The name of the database instance |  | 
-| Service Name a| String |  The name of the database service name |  | 
-| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy |  | 
+| Port a| Number |  Configures the port of the database |  1521 |
+| User a| String |  The user that is used for authentication against the database |  |
+| Password a| String |  The password that is used for authentication against the database |  |
+| Instance a| String |  The name of the database instance |  |
+| Service Name a| String |  The name of the database service name |  |
+| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy |  |
 |===
 
 == Supported Operations
-* <<bulkDelete>> 
-* <<bulkInsert>> 
-* <<bulkUpdate>> 
-* <<delete>> 
-* <<executeDdl>> 
-* <<executeScript>> 
-* <<insert>> 
-* <<select>> 
-* <<storedProcedure>> 
-* <<update>> 
+* <<bulkDelete>>
+* <<bulkInsert>>
+* <<bulkUpdate>>
+* <<delete>>
+* <<executeDdl>>
+* <<executeScript>>
+* <<insert>>
+* <<select>>
+* <<storedProcedure>>
+* <<update>>
 
 ==== Associated Sources
-* <<listener>> 
+* <<listener>>
 
 
 == Operations
@@ -224,13 +225,13 @@ Allows executing one delete statement various times using different parameter bi
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Input Parameters a| Array of Object |  A List of Maps in which every list item represents a row to be inserted, and the map contains the parameter names as keys and the value the parameter is bound to. |  `#[payload]` | 
+| Input Parameters a| Array of Object |  A List of Maps in which every list item represents a row to be inserted, and the map contains the parameter names as keys and the value the parameter is bound to. |  `#[payload]` |
 | Transactional Action a| Enumeration, one of:
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -239,15 +240,15 @@ Allows executing one delete statement various times using different parameter bi
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -257,13 +258,13 @@ Allows executing one delete statement various times using different parameter bi
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[bulkInsert]]
@@ -279,13 +280,13 @@ Allows executing one insert statement various times using different parameter bi
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Input Parameters a| Array of Object |  A list of maps in which every list item represents a row to be inserted, and the map contains the parameter names as keys and the value the parameter is bound to. |  `#[payload]` | 
+| Input Parameters a| Array of Object |  A list of maps in which every list item represents a row to be inserted, and the map contains the parameter names as keys and the value the parameter is bound to. |  `#[payload]` |
 | Transactional Action a| Enumeration, one of:
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -294,15 +295,15 @@ Allows executing one insert statement various times using different parameter bi
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows you to optionally specify the type of one or more of the parameters in the query. If provided, you're not required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows you to optionally specify the type of one or more of the parameters in the query. If provided, you're not required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -312,13 +313,13 @@ Allows executing one insert statement various times using different parameter bi
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[bulkUpdate]]
@@ -333,13 +334,13 @@ Allows executing one update statement various times using different parameter bi
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Input Parameters a| Array of Object |  A list of maps in which every list item represents a row to be inserted, and the map contains the parameter names as keys and the value the parameter is bound to. |  `#[payload]` | 
+| Input Parameters a| Array of Object |  A list of maps in which every list item represents a row to be inserted, and the map contains the parameter names as keys and the value the parameter is bound to. |  `#[payload]` |
 | Transactional Action a| Enumeration, one of:
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -348,15 +349,15 @@ Allows executing one update statement various times using different parameter bi
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A *Time unit* that qualifies the `#queryTimeout` |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a ResultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A *Time unit* that qualifies the `#queryTimeout` |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a ResultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows you to optionally specify the type of one or more of the parameters in the query. If provided, you're not required to reference all of the parameters, but you cannot reference a parameter that's not present in the input values. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows you to optionally specify the type of one or more of the parameters in the query. If provided, you're not required to reference all of the parameters, but you cannot reference a parameter that's not present in the input values. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -366,13 +367,13 @@ Allows executing one update statement various times using different parameter bi
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[delete]]
@@ -392,8 +393,8 @@ Deletes data in a database.
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -402,16 +403,16 @@ Deletes data in a database.
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A *Time unit* that qualifies the #queryTimeout. |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a ResultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A *Time unit* that qualifies the #queryTimeout. |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a ResultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute. |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not required to reference all of the parameters, but you cannot reference a parameter that is not present in the input values. |  | 
-| Input Parameters a| Object |  A Map in which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not required to reference all of the parameters, but you cannot reference a parameter that is not present in the input values. |  |
+| Input Parameters a| Object |  A Map in which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -421,13 +422,13 @@ Deletes data in a database.
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[executeDdl]]
@@ -448,8 +449,8 @@ Enables execution of DDL queries against a database.
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -458,13 +459,13 @@ Enables execution of DDL queries against a database.
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A *Time unit* which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+** DAYS |  A *Time unit* which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -474,13 +475,13 @@ Enables execution of DDL queries against a database.
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[executeScript]]
@@ -500,10 +501,10 @@ Executes a SQL script in one single Database statement. The script is executed a
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| SQL Query Text a| String |  The text of the SQL query to execute |  | 
-| Script Path a| String |  The location of a file to load. The file can point to a resource on the classpath or on a disk. |  | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| SQL Query Text a| String |  The text of the SQL query to execute |  |
+| Script Path a| String |  The location of a file to load. The file can point to a resource on the classpath or on a disk. |  |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -512,13 +513,13 @@ Executes a SQL script in one single Database statement. The script is executed a
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -528,13 +529,13 @@ Executes a SQL script in one single Database statement. The script is executed a
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[insert]]
@@ -554,8 +555,8 @@ Inserts data into a Database
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -564,19 +565,19 @@ Inserts data into a Database
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  | 
-| Input Parameters a| Object |  A Map which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  | 
-| Auto Generate Keys a| Boolean |  Indicates when to make auto-generated keys available for retrieval. |  false | 
-| Auto Generated Keys Column Indexes a| Array of Number |  List of column indexes that indicates which auto-generated keys to make available for retrieval. |  | 
-| Auto Generated Keys Column Names a| Array of String |  List of column names that indicates which auto-generated keys should be made available for retrieval. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  |
+| Input Parameters a| Object |  A Map which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  |
+| Auto Generate Keys a| Boolean |  Indicates when to make auto-generated keys available for retrieval. |  false |
+| Auto Generated Keys Column Indexes a| Array of Number |  List of column indexes that indicates which auto-generated keys to make available for retrieval. |  |
+| Auto Generated Keys Column Names a| Array of String |  List of column names that indicates which auto-generated keys should be made available for retrieval. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -586,13 +587,13 @@ Inserts data into a Database
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[select]]
@@ -612,11 +613,11 @@ Selects data from a database. Streaming is automatically applied to avoid preemp
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
 | Streaming Strategy a| * <<repeatable-in-memory-iterable>>
 * <<repeatable-file-store-iterable>>
-* non-repeatable-iterable |  Configure to use repeatable streams. |  | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+* non-repeatable-iterable |  Configure to use repeatable streams. |  |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -625,16 +626,16 @@ Selects data from a database. Streaming is automatically applied to avoid preemp
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  | 
-| Input Parameters a| Object |  A Map which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  |
+| Input Parameters a| Object |  A Map which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -644,12 +645,12 @@ Selects data from a database. Streaming is automatically applied to avoid preemp
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:BAD_SQL_SYNTAX
 
 
 [[storedProcedure]]
@@ -669,8 +670,8 @@ Invokes a Stored Procedure on the database.  When the stored procedure returns o
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -679,21 +680,21 @@ Invokes a Stored Procedure on the database.  When the stored procedure returns o
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  | 
-| Input Parameters a| Object |  A Map which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  | 
-| Input - Output Parameters a| Object |  A Map which keys are the name of a parameter to be set on the JDBC prepared statement which is both input and output.  Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  | 
-| Output Parameters a| Array of <<OutputParameter>> |  A list of output parameters to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: call multiply(:value, :result)) |  | 
-| Auto Generate Keys a| Boolean |  Indicates when to make auto-generated keys available for retrieval. |  false | 
-| Auto Generated Keys Column Indexes a| Array of Number |  List of column indexes that indicates which auto-generated keys to make available for retrieval. |  | 
-| Auto Generated Keys Column Names a| Array of String |  List of column names that indicates which auto-generated keys should be made available for retrieval. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  |
+| Input Parameters a| Object |  A Map which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  |
+| Input - Output Parameters a| Object |  A Map which keys are the name of a parameter to be set on the JDBC prepared statement which is both input and output.  Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  |
+| Output Parameters a| Array of <<OutputParameter>> |  A list of output parameters to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: call multiply(:value, :result)) |  |
+| Auto Generate Keys a| Boolean |  Indicates when to make auto-generated keys available for retrieval. |  false |
+| Auto Generated Keys Column Indexes a| Array of Number |  List of column indexes that indicates which auto-generated keys to make available for retrieval. |  |
+| Auto Generated Keys Column Names a| Array of String |  List of column names that indicates which auto-generated keys should be made available for retrieval. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -703,13 +704,13 @@ Invokes a Stored Procedure on the database.  When the stored procedure returns o
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 [[update]]
@@ -729,8 +730,8 @@ Updates data in a database.
 
 ** ALWAYS_JOIN
 ** JOIN_IF_POSSIBLE
-** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+** NOT_SUPPORTED |  The type of joining action that operations can take regarding transactions. |  JOIN_IF_POSSIBLE |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -739,19 +740,19 @@ Updates data in a database.
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | SQL Query Text a| String |  The text of the SQL query to execute |  | x
-| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  | 
-| Input Parameters a| Object |  A map in which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  | 
-| Auto Generate Keys a| Boolean |  Indicates when to make auto-generated keys available for retrieval. |  false | 
-| Auto Generated Keys Column Indexes a| Array of Number |  List of column indexes that indicates which auto-generated keys to make available for retrieval. |  | 
-| Auto Generated Keys Column Names a| Array of String |  List of column names that indicates which auto-generated keys should be made available for retrieval. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` | 
+| Parameter Types a| Array of <<ParameterType>> |  Allows to optionally specify the type of one or more of the parameters in the query. If provided, you're not even required to reference all of the parameters, but you cannot reference a parameter not present in the input values |  |
+| Input Parameters a| Object |  A map in which keys are the name of an input parameter to be set on the JDBC prepared statement. Each parameter should be referenced in the SQL text using a colon prefix (E.g: where id = :myParamName)).  The map's values will contain the actual assignation for each parameter. |  |
+| Auto Generate Keys a| Boolean |  Indicates when to make auto-generated keys available for retrieval. |  false |
+| Auto Generated Keys Column Indexes a| Array of Number |  List of column indexes that indicates which auto-generated keys to make available for retrieval. |  |
+| Auto Generated Keys Column Names a| Array of String |  List of column names that indicates which auto-generated keys should be made available for retrieval. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -761,13 +762,13 @@ Updates data in a database.
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* DB:QUERY_EXECUTION 
-* DB:CONNECTIVITY 
-* DB:RETRY_EXHAUSTED 
-* DB:BAD_SQL_SYNTAX 
+* DB:QUERY_EXECUTION
+* DB:CONNECTIVITY
+* DB:RETRY_EXHAUSTED
+* DB:BAD_SQL_SYNTAX
 
 
 == Sources
@@ -786,20 +787,20 @@ Selects from a table at a regular interval and generates one message per each ob
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Table a| String |  The name of the table to select from |  | x
-| Watermark Column a| String |  The name of the column to use for watermark. Values taken from this column will be used to filter the contents of the next poll, so that only rows with a greater watermark value are processed. |  | 
-| Id Column a| String |  The name of the column to consider as row ID. If provided, this component will make sure that the same row is not processed twice by concurrent polls. |  | 
+| Watermark Column a| String |  The name of the column to use for watermark. Values taken from this column will be used to filter the contents of the next poll, so that only rows with a greater watermark value are processed. |  |
+| Id Column a| String |  The name of the column to consider as row ID. If provided, this component will make sure that the same row is not processed twice by concurrent polls. |  |
 | Transactional Action a| Enumeration, one of:
 
 ** ALWAYS_BEGIN
-** NONE |  The type of beginning action that sources can take regarding transactions. |  NONE | 
+** NONE |  The type of beginning action that sources can take regarding transactions. |  NONE |
 | Transaction Type a| Enumeration, one of:
 
 ** LOCAL
-** XA |  The type of transaction to create. Availability depends on the runtime version. |  LOCAL | 
-| Primary Node Only a| Boolean |  Whether this source should only be executed on the primary node when running in Cluster |  | 
+** XA |  The type of transaction to create. Availability depends on the runtime version. |  LOCAL |
+| Primary Node Only a| Boolean |  Whether this source should only be executed on the primary node when running in Cluster |  |
 | Scheduling Strategy a| scheduling-strategy |  Configures the scheduler that triggers the polling |  | x
-| Redelivery Policy a| <<RedeliveryPolicy>> |  Defines a policy for processing the redelivery of the same message |  | 
-| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 | 
+| Redelivery Policy a| <<RedeliveryPolicy>> |  Defines a policy for processing the redelivery of the same message |  |
+| Query Timeout a| Number |  Indicates the minimum amount of time before the JDBC driver attempts to cancel a running statement. No timeout is used by default. |  0 |
 | Query Timeout Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -808,11 +809,11 @@ Selects from a table at a regular interval and generates one message per each ob
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS | 
-| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  | 
-| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  | 
+** DAYS |  A TimeUnit which qualifies the #queryTimeout |  SECONDS |
+| Fetch Size a| Number |  Indicates how many rows to fetch from the database when rows are read from a resultSet. This property is required when streaming is true; in that case a default value (10) is used. |  |
+| Max Rows a| Number |  Sets the limit for the maximum number of rows that any ResultSet object generated by this message processor can contain for the given number. If the limit is exceeded, the excess rows are silently dropped. |  |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -822,7 +823,7 @@ Selects from a table at a regular interval and generates one message per each ob
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 
 
@@ -833,12 +834,12 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Pool Size a| Number | Maximum number of connections a pool maintains at any given time | 5 | 
-| Min Pool Size a| Number | Minimum number of connections a pool maintains at any given time | 0 | 
-| Acquire Increment a| Number | Determines how many connections at a time to try to acquire when the pool is exhausted | 1 | 
-| Prepared Statement Cache Size a| Number | Determines how many statements are cached per pooled connection. Setting this to zero will disable statement caching | 5 | 
+| Max Pool Size a| Number | Maximum number of connections a pool maintains at any given time | 5 |
+| Min Pool Size a| Number | Minimum number of connections a pool maintains at any given time | 0 |
+| Acquire Increment a| Number | Determines how many connections at a time to try to acquire when the pool is exhausted | 1 |
+| Prepared Statement Cache Size a| Number | Determines how many statements are cached per pooled connection. Setting this to zero will disable statement caching | 5 |
 | Max Wait a| Number | The amount of time a client trying to obtain a connection waits for it to be acquired when the pool is
- exhausted. Zero (default) means wait indefinitely | 0 | 
+ exhausted. Zero (default) means wait indefinitely | 0 |
 | Max Wait Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -847,7 +848,7 @@ Selects from a table at a regular interval and generates one message per each ob
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS | A #maxWait. | SECONDS | 
+** DAYS | A #maxWait. | SECONDS |
 |===
 
 [[ColumnType]]
@@ -858,7 +859,7 @@ Selects from a table at a regular interval and generates one message per each ob
 | Field | Type | Description | Default Value | Required
 | Id a| Number | Type identifier used by the JDBC driver. |  | x
 | Type Name a| String | Name of the data type used by the JDBC driver. |  | x
-| Class Name a| String | Indicates which Java class must be used to map the DB type. |  | 
+| Class Name a| String | Indicates which Java class must be used to map the DB type. |  |
 |===
 
 [[Reconnection]]
@@ -867,9 +868,9 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
+| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to true, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> | The reconnection strategy to use. |  | 
+* <<reconnect-forever>> | The reconnection strategy to use. |  |
 |===
 
 [[reconnect]]
@@ -878,8 +879,8 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Frequency a| Number | How often in milliseconds to reconnect |  | 
-| Count a| Number | How many reconnection attempts to make. |  | 
+| Frequency a| Number | How often in milliseconds to reconnect |  |
+| Count a| Number | How many reconnection attempts to make. |  |
 |===
 
 [[reconnect-forever]]
@@ -888,7 +889,7 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Frequency a| Number | How often in milliseconds to reconnect |  | 
+| Frequency a| Number | How often in milliseconds to reconnect |  |
 |===
 
 [[ExpirationPolicy]]
@@ -897,7 +898,7 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Idle Time a| Number | A scalar time value for the maximum amount of time a dynamic configuration instance should be allowed to be idle before it's considered eligible for expiration |  | 
+| Max Idle Time a| Number | A scalar time value for the maximum amount of time a dynamic configuration instance should be allowed to be idle before it's considered eligible for expiration |  |
 | Time Unit a| Enumeration, one of:
 
 ** NANOSECONDS
@@ -906,7 +907,7 @@ Selects from a table at a regular interval and generates one message per each ob
 ** SECONDS
 ** MINUTES
 ** HOURS
-** DAYS | A time unit that qualifies the maxIdleTime attribute |  | 
+** DAYS | A time unit that qualifies the maxIdleTime attribute |  |
 |===
 
 [[RedeliveryPolicy]]
@@ -915,11 +916,11 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Redelivery Count a| Number | The maximum number of times a message can be redelivered and processed unsuccessfully before triggering process-failed-message |  | 
-| Use Secure Hash a| Boolean | Whether to use a secure hash algorithm to identify a redelivered message. |  | 
-| Message Digest Algorithm a| String | The secure hashing algorithm to use. If not set, the default is SHA-256. |  | 
-| Id Expression a| String | Defines one or more expressions to use to determine when a message has been redelivered. This property may only be set if useSecureHash is false. |  | 
-| Object Store a| Object Store | The object store where the redelivery counter for each message is going to be stored. |  | 
+| Max Redelivery Count a| Number | The maximum number of times a message can be redelivered and processed unsuccessfully before triggering process-failed-message |  |
+| Use Secure Hash a| Boolean | Whether to use a secure hash algorithm to identify a redelivered message. |  |
+| Message Digest Algorithm a| String | The secure hashing algorithm to use. If not set, the default is SHA-256. |  |
+| Id Expression a| String | Defines one or more expressions to use to determine when a message has been redelivered. This property may only be set if useSecureHash is false. |  |
+| Object Store a| Object Store | The object store where the redelivery counter for each message is going to be stored. |  |
 |===
 
 [[ParameterType]]
@@ -976,8 +977,8 @@ Selects from a table at a regular interval and generates one message per each ob
 ** LONGNVARCHAR
 ** NCLOB
 ** SQLXML
-** UNKNOWN |  |  | 
-| Custom Type a| String |  |  | 
+** UNKNOWN |  |  |
+| Custom Type a| String |  |  |
 |===
 
 [[StatementResult]]
@@ -986,8 +987,8 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Affected Rows a| Number |  |  | 
-| Generated Keys a| Object |  |  | 
+| Affected Rows a| Number |  |  |
+| Generated Keys a| Object |  |  |
 |===
 
 [[repeatable-in-memory-iterable]]
@@ -996,9 +997,9 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Initial Buffer Size a| Number | The amount of instances that is initially be allowed to be kept in memory to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then the buffer expands according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. Default value is 100 instances. |  | 
-| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised when the buffer gets full. Default value is 100 instances. |  | 
-| Max Buffer Size a| Number | The maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower than or equal to zero means no limit. |  | 
+| Initial Buffer Size a| Number | The amount of instances that is initially be allowed to be kept in memory to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then the buffer expands according to the bufferSizeIncrement attribute, with an upper limit of maxInMemorySize. Default value is 100 instances. |  |
+| Buffer Size Increment a| Number | This is by how much the buffer size expands if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, meaning that a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised when the buffer gets full. Default value is 100 instances. |  |
+| Max Buffer Size a| Number | The maximum amount of memory to use. If more than that is used then a STREAM_MAXIMUM_SIZE_EXCEEDED error is raised. A value lower than or equal to zero means no limit. |  |
 |===
 
 [[repeatable-file-store-iterable]]
@@ -1007,13 +1008,13 @@ Selects from a table at a regular interval and generates one message per each ob
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| In Memory Objects a| Number | The maximum amount of instances that will be kept in memory. If more than that is required, then it will start to buffer the content on disk. |  | 
+| In Memory Objects a| Number | The maximum amount of instances that will be kept in memory. If more than that is required, then it will start to buffer the content on disk. |  |
 | Buffer Unit a| Enumeration, one of:
 
 ** BYTE
 ** KB
 ** MB
-** GB | The unit in which maxInMemorySize is expressed |  | 
+** GB | The unit in which maxInMemorySize is expressed |  |
 |===
 
 [[OutputParameter]]

--- a/modules/ROOT/pages/workday/workday-connector-design-center.adoc
+++ b/modules/ROOT/pages/workday/workday-connector-design-center.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../../assets/images/
-:page-aliases: workday-design-center.adoc
+:page-aliases: workday/workday-design-center.adoc
 
 Anypoint Design Center's Flow Designer enables you to create apps visually. To use Flow Designer, work with your Anypoint Platform administrator to ensure that you have a xref:access-management::environments.adoc#to-create-a-new-environment[Design environment]. For more information, see the xref:design-center::fd-tour.adoc[Flow Designer Tour].
 
@@ -17,7 +17,7 @@ the xref:workday/workday-reference.adoc[Workday Connector Reference].
 
 == Configure the Input Source Trigger
 
-A trigger starts your app. Workday Connector provides the New Object Trigger operation that starts your app when a new object is created in Workday. Alternatively, you can use the HTTP Listener operation to start your app from a browser 
+A trigger starts your app. Workday Connector provides the New Object Trigger operation that starts your app when a new object is created in Workday. Alternatively, you can use the HTTP Listener operation to start your app from a browser
 or with a command such as `curl`. Another alternative is to use Scheduler to start your app on a timed schedule.
 
 . In Design Center, click *Create*.
@@ -46,7 +46,7 @@ Design Center automatically saves all changes.
 
 == Configure the Target Component
 
-The target component enables your app to process data received from the trigger. Workday Connector 
+The target component enables your app to process data received from the trigger. Workday Connector
 provides operations that you can use to perform tasks for educational organizations, human resources, professional services,
 payroll, and benefits administration.
 

--- a/modules/ROOT/pages/workday/workday-connector-examples.adoc
+++ b/modules/ROOT/pages/workday/workday-connector-examples.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../../assets/images/
-:page-aliases: workday-to-add-fund-to-service.adoc, workday-to-create-position.adoc
+:page-aliases: workday/workday-to-add-fund-to-service.adoc, workday/workday-to-create-position.adoc
 
 Anypoint Connector for Workday provides two financial management services examples that enable you to see how Workday Connector works in Anypoint Design Center’s Flow Designer.
 
@@ -18,7 +18,7 @@ You need access to Workday and your Workday user name, password, and tenant name
 . In Design Center, click *Create*.
 . Click *Create new application* to open Flow Designer.
 . Specify a value for *Project name*, and click *Create*.
-. In *Let's get started*, select HTTP Connector and Listener. 
+. In *Let's get started*, select HTTP Connector and Listener.
 . Click *Next*.
 . For the target, search for "Workday" and select *Workday Connector*.
 . In *Operation*, search for "fin" and select *Financial Management*.
@@ -61,7 +61,7 @@ Configuration example:
 . Click *Save*.
 . Click *+* and, in *Select a component*, select *Logger*.
 . Set *Message* to `payload` (or `#[payload]`).
-. Click *Test* at the right of the taskbar. 
+. Click *Test* at the right of the taskbar.
 . After the test is successful, click the down-arrow menu in the taskbar and select *Deploy application*.
 . After the project is running, check for a response.
 . Click your browser's back button to return to the list of Design Center projects.

--- a/modules/ROOT/pages/workday/workday-connector-studio.adoc
+++ b/modules/ROOT/pages/workday/workday-connector-studio.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../../assets/images/
-:page-aliases: workday-studio.adoc
+:page-aliases: workday/workday-studio.adoc
 
 To configure Anypoint Connector for Workday:
 
@@ -63,7 +63,7 @@ The required fields for the On New Objects input source are:
 
 * *Fixed Frequency*
 +
-Polls for data at a specified number of milliseconds, seconds, minutes, hours, or days. The default is 1000 milliseconds. 
+Polls for data at a specified number of milliseconds, seconds, minutes, hours, or days. The default is 1000 milliseconds.
 * *Cron*
 +
 Accepts an expression that polls for data based on a filter, such as, every Monday in a month at a given time. See xref:4.2@mule-runtime::scheduler-concept.adoc#cron-expressions[Cron Expressions] for examples.

--- a/modules/ROOT/pages/workday/workday-connector-xml-maven.adoc
+++ b/modules/ROOT/pages/workday/workday-connector-xml-maven.adoc
@@ -3,8 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../../assets/images/
-
-:page-aliases: workday-xml-ref.adoc
+:page-aliases: workday/workday-xml-ref.adoc
 
 If you manually code a Mule app in XML either from the Anypoint Studio XML editor or from a text editor, you can get access to Workday in your app by adding reference statements to your XML Mule flow and in the Apache Maven `pom.xml` file.
 

--- a/modules/ROOT/pages/workday/workday-connector.adoc
+++ b/modules/ROOT/pages/workday/workday-connector.adoc
@@ -3,8 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../../assets/images/
-
-:page-aliases: workday-about.adoc
+:page-aliases: workday/workday-about.adoc
 
 Support Category: Select
 
@@ -12,7 +11,7 @@ Workday Connector Version 11.1.0
 
 Anypoint Connector for Workday (Workday Connector) provides access to standard Workday operations.
 Workday is a Software-as-a-Service (SaaS) solution developed by Workday, Inc.
-Workday provides a set of software apps for financial and human capital management, such as 
+Workday provides a set of software apps for financial and human capital management, such as
 human resources, staffing, recruiting, and performance.
 
 == About Connectors


### PR DESCRIPTION
Found some broken links in the Studio build that pointed to these redirects.
Some of these page-aliases were incomplete (sub-directory was missing), and some other were simply being ignored due to an extra line that separated them from the rest of the metadata declaration. 

