### PR TITLE
Kafka - Mule 4 fix for project yaml

### DIFF
--- a/modules/ROOT/pages/kafka/kafka-connector-examples.adoc
+++ b/modules/ROOT/pages/kafka/kafka-connector-examples.adoc
@@ -22,7 +22,7 @@ Construct a flow as follows:
 |Bootstrap servers |`${config.basic.bootstrapServers}` |Comma-separated host-port pairs used to establish the initial connection to the Kafka cluster.
 |===
 +
-. Declare and complete the variables described above on the corresponding YAML file (example: src/main/resoures/properties/project_name_dev.yaml) and load that properties file as a global element. 
+. Declare and complete the variables previously described in the corresponding YAML file (for example: src/main/resoures/properties/project_name_dev.yaml), and load that properties file as a global element. 
 . Drag *Logger* to the canvas and set the message to:
 +
 [source,xml]

--- a/modules/ROOT/pages/kafka/kafka-connector-examples.adoc
+++ b/modules/ROOT/pages/kafka/kafka-connector-examples.adoc
@@ -22,7 +22,7 @@ Construct a flow as follows:
 |Bootstrap servers |`${config.basic.bootstrapServers}` |Comma-separated host-port pairs used to establish the initial connection to the Kafka cluster.
 |===
 +
-. Add the values for each field in the `mule-app.properties` file.
+. Declare and complete the variables described above on the corresponding YAML file (example: src/main/resoures/properties/project_name_dev.yaml) and load that properties file as a global element. 
 . Drag *Logger* to the canvas and set the message to:
 +
 [source,xml]


### PR DESCRIPTION
The original line refers to a mule3 standard, The updated one is for the YAML files used by Mule4 and the extra step and remind the user to add that properties file as a global element.

Thanks
Santiago