### PR TITLE
Add example on "Configure a Target"

### DIFF
--- a/modules/ROOT/pages/http/http-request-ref.adoc
+++ b/modules/ROOT/pages/http/http-request-ref.adoc
@@ -162,7 +162,19 @@ A range of failure status codes is defined by two ASCII `..` full stop character
 
 == Configure a Target
 
-By default, the body of a request is taken from the `#[payload]` of the incoming Mule message and the response is sent onwards as the `#[payload]` of the output Mule message. You can change this default behavior through the General > Request > Body and General > Output > Target Variable attributes. Use this attribute to specify a location other than payload for the output data, such as a variable.
+By default, the body of a request is taken from the `#[payload]` of the incoming Mule message and the response is sent onwards as the `#[payload]` of the output Mule message. You can change this default behavior through the General > Request > Body and General > Output > Target Variable attributes. Use this attribute to specify a location other than payload for the output data, such as a variable. If you set the Target Variable the output Mule message wont be on the flow. For save more data than the payload, you need to modify the target value.
+Here is an example for save the Payload and Attributes.
+[source,xml,linenums]
+----
+<http:request method="GET" doc:name="Request" doc:id="02826240-05b4-49f5-a1a9-e8959c036bf2" config-ref="HTTP_Request_configuration" path="/" target="somevar" targetValue="#[%dw 2.0
+output application/java
+---
+{
+	payld: payload,
+	attr: attributes
+}]"/>
+----
+
 
 == Configure Request Streaming
 


### PR DESCRIPTION
I add an example on Configure a Target and detail that if you save the output to a variable, the mule message will not be persistent on the flow. The example show how to save payload and attributes.