### PR TITLE
Correction to publish and publish-consume descriptions

### DIFF
--- a/modules/ROOT/pages/vm/vm-reference.adoc
+++ b/modules/ROOT/pages/vm/vm-reference.adoc
@@ -68,7 +68,7 @@ Returns instances of VMConnection.
 
 Pull a message from a queue. If a message is not immediately available, the Consume operation waits for up to the configured `queueTimeout` value, after which a VM:QUEUE_TIMEOUT error is thrown.
 
-The queue in which the content is published cannot contain a Listener (`<vm:listener>`) source.
+The flow in which the content is published cannot contain a Listener (`<vm:listener>`) source.
 
 ==== Parameters
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
@@ -168,7 +168,7 @@ Publishes the given content into a queue, and then waits up to the queueTimeout 
 
 The temporal reply queue is automatically disposed after a response is received or the timeout expires.
 
-The queue in which the content is published cannot contain a Listener (`<vm:listener>`) source.
+The flow in which the content is published cannot contain a Listener (`<vm:listener>`) source.
 
 
 ==== Parameters


### PR DESCRIPTION
Modify the line: "The queue in which the content is published cannot contain a Listener (<vm:listener>) source."
to
"The flow in which the content is published cannot contain a Listener (<vm:listener>) source."
This statement is part of publish and publish-consume operations descriptions