### PR TITLE
Fixed incorrect parameter name

### DIFF
--- a/modules/ROOT/pages/ldap/ldap-connector.adoc
+++ b/modules/ROOT/pages/ldap/ldap-connector.adoc
@@ -11,8 +11,7 @@ Anypoint Connector for Lightweight Directory Access Protocol (LDAP) is a public 
 
 Many LDAP servers are included in free-use open source projects and packages. The particulars of installing, running and configuring LDAP servers fall outside the scope of this document.
 
-This document provides
-an example of a simple LDAP Extension configuration, including basic instructions for installing and connecting to an LDAP server using the LDAP connector.
+This document provides an example of a simple LDAP Connector configuration, including basic instructions for installing and connecting to an LDAP server using LDAP Connector.
 
 Release Notes: xref:release-notes::connector/ldap-connector-release-notes-mule-4.adoc[LDAP Connector Release Notes] +
 Exchange: https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-ldap-connector/[LDAP Connector]
@@ -52,7 +51,7 @@ Anypoint Exchange and click *Dependency Snippets*.
 [[compatibility]]
 === Compatibility
 
-The LDAP connector is compatible with:
+LDAP Connector is compatible with:
 
 [%header,cols="20a,80a",width=70%]
 |===
@@ -88,35 +87,40 @@ Anypoint Studio provides two ways to add the connector to your Studio project: f
 [[config]]
 == Configure the LDAP Connector Global Element
 
-To use the LDAP connector in a Mule application, you must configure a global LDAP configuration element that can be used by as many LDAP connectors as you require for your application. Note that this connector supports server side pooling for Basic configuration, which can be configured in the Pooling section.
+To use LDAP Connector in a Mule application, you must configure a global LDAP configuration element that can be used by as many LDAP connectors as you require for your application. Note that this connector supports server side pooling for Basic configuration, which can be configured in the Pooling section.
 
-. Click the Global Elements tab at the base of the canvas.
-. On the Global Configuration Elements screen, click Create. Following window would be displayed.
+. Click the *Global Elements* tab at the base of the canvas.
+. On the Global Configuration Elements screen, click *Create*. +
+The following window appears:
 +
 image::ldap/ldap-config-global-wizard.png[Global Element Configuration Wizard]
 +
-. In the Choose Global Type wizard, expand Connector Configuration and select LDAP Configuration and click Ok. Following window would be displayed.
+. In the Choose Global Type wizard, expand *Connector Configuration*, select *LDAP Configuration*, and click *Ok*. +
+The following window appears:
 +
 image::ldap/ldap-configs.png[Global Element Properties]
 +
-. Choose among one of the 2 configurations provided in the drop down list - one for Basic and the other for TLS configuration and configure its properties.
+. Choose from one of the two configurations provided in the drop-down list (one for Basic and the other for TLS configuration) and configure its properties.
 +
 [%header,cols="30a,70a",width=80%]
 |===
 |Parameter|Description
-|Name|Enter a name for the configuration to reference it.
+|Name| Name by which to reference the connector
 |Principal DN|The DN (distinguished name) of the user
 |Password|The password of the user
-|Authentication|Specifies the authentication mechanism to use. Default: Simple
+|Authentication|Specifies the authentication mechanism to use. The default is `Simple`.
 |URL|The connection URL to the LDAP server
 |===
 +
 In the image above, the placeholder values refer to a configuration file `mule-artifact.properties` placed in the `src/main/resources` folder of your project.
- You can either enter your credentials into the global configuration properties, or reference a configuration file that contains these values. For simpler maintenance and better re-usability of your project, Mule recommends that you use a configuration file. Keeping these values in a separate file is useful if you need to deploy to different environments, such as production, development, and QA, where your access credentials differ.
+ You can either enter your credentials into the global configuration properties, or reference a configuration file that contains these values. 
+ 
+ Although you can hardcode your credentials into the global configuration properties, you can simplify maintenance and achieve better project reusability if you reference a configuration file that contains these values instead. Keeping these values in a separate file is useful if you need to deploy to different environments in which your access credentials differ (such as production, development, and QA).
 
-. Keep the Advanced tab and the Pooling tabs with their default entries. Pooling tab is only available for Basic configuration.
-. Click Test Connection to confirm that the parameters of your global configuration are accurate, and that Mule is able to successfully connect to your instance of LDAP server.
-. Click OK to save the global connector configurations.
+. In the Advanced and Pooling tabs, keep the default entries. + 
+The Pooling tab is only available for Basic configuration.
+. Click *Test Connection* to confirm that the parameters of your global configuration are accurate, and that Mule is able to successfully connect to your instance of LDAP server.
+. Click *OK* to save the global connector configurations.
 
 == Configure With the XML Editor or Standalone
 
@@ -242,7 +246,7 @@ image::ldap/ldap-usecase-settings.png[Flow Settings]
 |Field|Description
 |Display Name|Enter a unique label for the LDAP operation in your application.
 2+|Basic Settings
-|Extension configuration|Connect to a global element linked to this connector. Global elements encapsulate reusable data about the connection to the target resource or service. Select the global LDAP connector element that you had created.
+|Connector configuration|Connect to a global element linked to this connector. Global elements encapsulate reusable data about the connection to the target resource or service. Select the global LDAP connector element that you had created.
 2+|General
 |Entry|#[payload], which refers to a LDAPEntry object created in the previous component typically a DataWeave component and transformed as input payload to this processor
 |===
@@ -272,7 +276,7 @@ config.url=<URL>
 |===
 |Parameter|Value
 |Display Name|HTTP
-|Extension configuration| If no HTTP element has been created yet, click the plus sign to add a new HTTP Listener Configuration and click OK (leave the values to its defaults).
+|Connector configuration| If no HTTP element has been created yet, click the plus sign to add a new HTTP Listener Configuration and click OK (leave the values to its defaults).
 |Path|/
 |===
 +
@@ -291,7 +295,7 @@ output application/java
 ----
 +
 . Drag Add entry operation of the LDAP connector next to the DataWeave component to add the LDAP Entry.
-. Configure the LDAP connector by adding a new LDAP Global Element. Click the plus sign next to the Extension configuration field.
+. Configure the LDAP connector by adding a new LDAP Global Element. Click the plus sign next to the Connector configuration field.
 .. Configure the global element according to the table below:
 +
 [%header%autowidth]
@@ -318,20 +322,22 @@ output application/java
 	</ldap:config>
 ----
 +
-. Click Test Connection to confirm that Mule can connect with the LDAP server instance. If the connection is successful, click OK to save the configuration. Otherwise, review or correct any incorrect parameters, then test again.
-. Back in the properties editor of the LDAP connector, configure the parameters required for the add entry operation:
+. Click *Test Connection* to confirm that Mule can connect with the LDAP server instance.
+. If the connection is successful, click *OK* to save the configuration. +
+Otherwise, review or correct any incorrect parameters, then test again.
+. Return to the Properties editor of the LDAP connector, and configure the parameters required for the add entry operation:
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Add Group Entry to LDAP Directory
 2+|Basic Settings
-|Extension configuration|Select the global LDAP connector element that you had created.
+|Connector configuration|Select the global LDAP connector element that you had created.
 2+|General
 |Entry|#[payload], the default value
 |===
 +
-. Now let's create the organizational person entry using a DataWeave component. Drag the DataWeave component next to the LDAP connector and use the script below.
+. Create the organizational person entry using a DataWeave component. Drag the DataWeave component next to the LDAP connector and use the script below:
 +
 [source,java,linenums]
 ----
@@ -348,46 +354,46 @@ output application/java
 }
 ----
 +
-. Drag Add entry operation of the LDAP connector next to the DataWeave component to add the LDAP User Entry.
-. In the properties editor of the LDAP connector, configure the parameters as below:
+. Drag the LDAP Connector *Add entry* operation next to the DataWeave component to add the LDAP User Entry.
+. In the Properties editor of the LDAP connector, configure the parameters as follows:
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Add User Entry to LDAP Directory
 2+|Basic Settings
-|Extension configuration|Select the global LDAP connector element that you had created.
+|Connector configuration|Select the global LDAP connector element that you created.
 2+|General
 |Entry|#[payload], the default value
 |===
 +
-. Now that we have successfully added the entries, let's try to delete them using the LDAP connector.
-. Drag Delete entry operation of the LDAP connector next to the LDAP connector to delete the LDAP User Entry.
-. In the properties editor of the LDAP connector, configure the parameters as below:
+. Now that you have successfully added the entries, try to delete them using the LDAP connector.
+. Drag the *Delete entry* operation next to the LDAP connector to delete the LDAP User Entry.
+. In the Properties editor of the LDAP connector, configure the parameters as follows:
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Delete User Entry from LDAP Directory
 2+|Basic Settings
-|Extension configuration|Select the global LDAP connector element that you had created.
+|Connector configuration|Select the global LDAP connector element that you created.
 2+|General
 |DN|`#['cn=Test User,ou=DevOpsGroup,' ++ attributes.queryParams.dn]`
 |===
 +
-. Drag another Delete entry operation of the LDAP connector next to the LDAP connector to delete the LDAP Group Entry.
+. Drag another *Delete entry* operation next to the LDAP connector to delete the LDAP Group Entry.
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Delete Group Entry from LDAP Directory
 2+|Basic Settings
-|Extension configuration|Select the global LDAP connector element that you had created.
+|Connector configuration|Select the global LDAP connector element that you had created.
 2+|General
 |DN|`#['ou=DevOpsGroup,' ++ attributes.queryParams.dn]`
 |===
 +
-. Finally drag the DataWeave component next to the LDAP connector to set the payload to "Flow Successfully Completed".
+. Finally, drag the DataWeave component next to the LDAP connector to set the payload to "Flow Successfully Completed".
 
 [[example-code]]
 === Example Use Case 1 Code

--- a/modules/ROOT/pages/ldap/ldap-connector.adoc
+++ b/modules/ROOT/pages/ldap/ldap-connector.adoc
@@ -19,12 +19,12 @@ Exchange: https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-ldap-co
 [[prerequisites]]
 == Prerequisites
 
-To use the LDAP connector, you must have the following:
+To use the LDAP Connector, you must have the following:
 
 * Access to either an OpenLDAP, Apache Directory, or MicroSoft Active Directory Instance.
 * Anypoint Studio version 7.0 (or higher) or Anypoint Design Center.
 
-To use the LDAP connector in a production environment, you must have either:
+To use the LDAP Connector in a production environment, you must have either:
 
 * An Enterprise license to use Mule.
 * A CloudHub Starter, Professional, or Enterprise account.
@@ -44,7 +44,7 @@ Anypoint Studio essentials, elements in a Mule flow, and global elements.
 </dependency>
 ----
 
-Mule converts RELEASE to the latest version. To specify a version, view 
+Mule converts RELEASE to the latest version. To specify a version, view
 https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-ldap-connector/[LDAP Connector] in
 Anypoint Exchange and click *Dependency Snippets*.
 
@@ -87,7 +87,7 @@ Anypoint Studio provides two ways to add the connector to your Studio project: f
 [[config]]
 == Configure the LDAP Connector Global Element
 
-To use LDAP Connector in a Mule application, you must configure a global LDAP configuration element that can be used by as many LDAP connectors as you require for your application. Note that this connector supports server side pooling for Basic configuration, which can be configured in the Pooling section.
+To use LDAP Connector in a Mule application, you must configure a global LDAP configuration element that can be used by as many LDAP Connectors as you require for your application. This connector supports server side pooling for Basic configuration, which can be configured in the Pooling section.
 
 . Click the *Global Elements* tab at the base of the canvas.
 . On the Global Configuration Elements screen, click *Create*. +
@@ -95,12 +95,12 @@ The following window appears:
 +
 image::ldap/ldap-config-global-wizard.png[Global Element Configuration Wizard]
 +
-. In the Choose Global Type wizard, expand *Connector Configuration*, select *LDAP Configuration*, and click *Ok*. +
+. In the Choose Global Type wizard, expand *Connector Configuration*, select *LDAP Configuration*, and click *OK*. +
 The following window appears:
 +
 image::ldap/ldap-configs.png[Global Element Properties]
 +
-. Choose from one of the two configurations provided in the drop-down list (one for Basic and the other for TLS configuration) and configure its properties.
+. Choose Basic configuration or TLS configuration from the drop-down list and configure its properties.
 +
 [%header,cols="30a,70a",width=80%]
 |===
@@ -113,14 +113,14 @@ image::ldap/ldap-configs.png[Global Element Properties]
 |===
 +
 In the image above, the placeholder values refer to a configuration file `mule-artifact.properties` placed in the `src/main/resources` folder of your project.
- You can either enter your credentials into the global configuration properties, or reference a configuration file that contains these values. 
- 
- Although you can hardcode your credentials into the global configuration properties, you can simplify maintenance and achieve better project reusability if you reference a configuration file that contains these values instead. Keeping these values in a separate file is useful if you need to deploy to different environments in which your access credentials differ (such as production, development, and QA).
+ You can either enter your credentials into the global configuration properties, or reference a configuration file that contains these values.
 
-. In the Advanced and Pooling tabs, keep the default entries. + 
+ Although you can hard-code your credentials into the global configuration properties, you can simplify maintenance and achieve better project reusability if you reference a configuration file that contains these values instead. Keeping these values in a separate file is useful if you need to deploy to different environments in which your access credentials differ (such as production, development, and QA).
+
+. In the Advanced and Pooling tabs, keep the default entries. +
 The Pooling tab is only available for Basic configuration.
 . Click *Test Connection* to confirm that the parameters of your global configuration are accurate, and that Mule is able to successfully connect to your instance of LDAP server.
-. Click *OK* to save the global connector configurations.
+. Click *OK* to save the global connector configuration.
 
 == Configure With the XML Editor or Standalone
 
@@ -129,16 +129,16 @@ The Pooling tab is only available for Basic configuration.
 [source,xml,linenums]
 ----
 
-<mule xmlns:ldap="http://www.mulesoft.org/schema/mule/ldap" 
+<mule xmlns:ldap="http://www.mulesoft.org/schema/mule/ldap"
 	xmlns="http://www.mulesoft.org/schema/mule/core"
 	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
 	xmlns:spring="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	xsi:schemaLocation="http://www.springframework.org/schema/beans 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
 	http://www.springframework.org/schema/beans/spring-beans-current.xsd
-	http://www.mulesoft.org/schema/mule/core 
+	http://www.mulesoft.org/schema/mule/core
 	http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-	http://www.mulesoft.org/schema/mule/ldap 
+	http://www.mulesoft.org/schema/mule/ldap
 	http://www.mulesoft.org/schema/mule/ldap/current/mule-ldap.xsd">
 
 <!-- Put your flows and configuration elements here -->
@@ -165,7 +165,7 @@ The Pooling tab is only available for Basic configuration.
 [[using-the-connector]]
 == Use the Connector
 
-The LDAP connector supports the following operations:
+The LDAP Connector supports the following operations:
 
 [%header,cols="30s,70a"]
 |===
@@ -220,7 +220,7 @@ http://www.mulesoft.org/schema/mule/ldap http://www.mulesoft.org/schema/mule/lda
 [[use-cases-and-demos]]
 == Use Cases and Demos
 
-Listed below are the most common use cases for the LDAP connector, and some demo application walkthroughs.
+Listed below are the most common use cases for the LDAP Connector, and some demo application walkthroughs.
 
 [%autowidth]
 |===
@@ -234,7 +234,7 @@ Listed below are the most common use cases for the LDAP connector, and some demo
 
 . Create a new Mule project in Anypoint Studio.
 . Add a suitable Mule inbound endpoint, such as the HTTP listener at the beginning of the flow.
-. Drag any operation of the LDAP connector, such as Add entry operation and drop it onto the canvas.
+. Drag any operation of the LDAP Connector, such as Add entry operation and drop it onto the canvas.
 . Click the connector to open the Properties Editor.
 +
 image::ldap/ldap-usecase-settings.png[Flow Settings]
@@ -246,7 +246,7 @@ image::ldap/ldap-usecase-settings.png[Flow Settings]
 |Field|Description
 |Display Name|Enter a unique label for the LDAP operation in your application.
 2+|Basic Settings
-|Connector configuration|Connect to a global element linked to this connector. Global elements encapsulate reusable data about the connection to the target resource or service. Select the global LDAP connector element that you had created.
+|Connector configuration|Connect to a global element linked to this connector. Global elements encapsulate reusable data about the connection to the target resource or service. Select the global LDAP Connector element that you created.
 2+|General
 |Entry|#[payload], which refers to a LDAPEntry object created in the previous component typically a DataWeave component and transformed as input payload to this processor
 |===
@@ -276,7 +276,7 @@ config.url=<URL>
 |===
 |Parameter|Value
 |Display Name|HTTP
-|Connector configuration| If no HTTP element has been created yet, click the plus sign to add a new HTTP Listener Configuration and click OK (leave the values to its defaults).
+|Connector configuration| If no HTTP element has been created yet, click the plus sign to add a new HTTP Listener Configuration and click *OK*. Leave the values to its defaults.
 |Path|/
 |===
 +
@@ -294,8 +294,8 @@ output application/java
 }
 ----
 +
-. Drag Add entry operation of the LDAP connector next to the DataWeave component to add the LDAP Entry.
-. Configure the LDAP connector by adding a new LDAP Global Element. Click the plus sign next to the Connector configuration field.
+. Drag Add entry operation of the LDAP Connector next to the DataWeave component to add the LDAP Entry.
+. Configure the LDAP Connector by adding a new LDAP global element. Click the plus sign next to the _Connector configuration_ field.
 .. Configure the global element according to the table below:
 +
 [%header%autowidth]
@@ -325,19 +325,19 @@ output application/java
 . Click *Test Connection* to confirm that Mule can connect with the LDAP server instance.
 . If the connection is successful, click *OK* to save the configuration. +
 Otherwise, review or correct any incorrect parameters, then test again.
-. Return to the Properties editor of the LDAP connector, and configure the parameters required for the add entry operation:
+. Return to the Properties editor of the LDAP Connector, and configure the parameters required for the add entry operation:
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Add Group Entry to LDAP Directory
 2+|Basic Settings
-|Connector configuration|Select the global LDAP connector element that you had created.
+|Connector configuration|Select the global LDAP Connector element that you created.
 2+|General
 |Entry|#[payload], the default value
 |===
 +
-. Create the organizational person entry using a DataWeave component. Drag the DataWeave component next to the LDAP connector and use the script below:
+. Create the organizational person entry using a DataWeave component. Drag the DataWeave component next to the LDAP Connector and use the following script:
 +
 [source,java,linenums]
 ----
@@ -355,45 +355,45 @@ output application/java
 ----
 +
 . Drag the LDAP Connector *Add entry* operation next to the DataWeave component to add the LDAP User Entry.
-. In the Properties editor of the LDAP connector, configure the parameters as follows:
+. In the Properties editor of the LDAP Connector, configure the parameters as follows:
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Add User Entry to LDAP Directory
 2+|Basic Settings
-|Connector configuration|Select the global LDAP connector element that you created.
+|Connector configuration|Select the global LDAP Connector element that you created.
 2+|General
 |Entry|#[payload], the default value
 |===
 +
-. Now that you have successfully added the entries, try to delete them using the LDAP connector.
-. Drag the *Delete entry* operation next to the LDAP connector to delete the LDAP User Entry.
-. In the Properties editor of the LDAP connector, configure the parameters as follows:
+. Now that you have successfully added the entries, try to delete them using the LDAP Connector.
+. Drag the *Delete entry* operation next to the LDAP Connector to delete the LDAP User Entry.
+. In the Properties editor of the LDAP Connector, configure the parameters as follows:
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Delete User Entry from LDAP Directory
 2+|Basic Settings
-|Connector configuration|Select the global LDAP connector element that you created.
+|Connector configuration|Select the global LDAP Connector element that you created.
 2+|General
 |DN|`#['cn=Test User,ou=DevOpsGroup,' ++ attributes.queryParams.dn]`
 |===
 +
-. Drag another *Delete entry* operation next to the LDAP connector to delete the LDAP Group Entry.
+. Drag another *Delete entry* operation next to the LDAP Connector to delete the LDAP Group Entry.
 +
 [%header%autowidth]
 |===
 |Parameter|Value
 |Display Name|Delete Group Entry from LDAP Directory
 2+|Basic Settings
-|Connector configuration|Select the global LDAP connector element that you had created.
+|Connector configuration|Select the global LDAP Connector element that you created.
 2+|General
 |DN|`#['ou=DevOpsGroup,' ++ attributes.queryParams.dn]`
 |===
 +
-. Finally, drag the DataWeave component next to the LDAP connector to set the payload to "Flow Successfully Completed".
+. Drag the DataWeave component next to the LDAP Connector to set the payload to "Flow Successfully Completed".
 
 [[example-code]]
 === Example Use Case 1 Code
@@ -404,22 +404,22 @@ Paste this code into your XML Editor to quickly load the flow for this example u
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 
-<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" 
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
 	xmlns:ldap="http://www.mulesoft.org/schema/mule/ldap"
 	xmlns:http="http://www.mulesoft.org/schema/mule/http"
 	xmlns="http://www.mulesoft.org/schema/mule/core"
-	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" 
-	xmlns:spring="http://www.springframework.org/schema/beans" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	xsi:schemaLocation="http://www.springframework.org/schema/beans 
+	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:spring="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
 	http://www.springframework.org/schema/beans/spring-beans-current.xsd
-	http://www.mulesoft.org/schema/mule/core 
+	http://www.mulesoft.org/schema/mule/core
 	http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-	http://www.mulesoft.org/schema/mule/http 
+	http://www.mulesoft.org/schema/mule/http
 	http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
-	http://www.mulesoft.org/schema/mule/ldap 
+	http://www.mulesoft.org/schema/mule/ldap
 	http://www.mulesoft.org/schema/mule/ldap/current/mule-ldap.xsd
-	http://www.mulesoft.org/schema/mule/ee/core 
+	http://www.mulesoft.org/schema/mule/ee/core
 	http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 
 
@@ -457,7 +457,7 @@ output application/java
 			</ee:message>
 		</ee:transform>
 
-		<ldap:add config-ref="LDAP_Configuration" 
+		<ldap:add config-ref="LDAP_Configuration"
 			doc:name="Add Group Entry to LDAP Directory" />
 
 
@@ -479,7 +479,7 @@ output application/java
 		</ee:transform>
 
 
-		<ldap:add config-ref="LDAP_Configuration" 
+		<ldap:add config-ref="LDAP_Configuration"
 			doc:name="Add User Entry to LDAP Directory" />
 
 		<ldap:delete config-ref="LDAP_Configuration"
@@ -487,7 +487,7 @@ output application/java
 			doc:name="Delete User Entry from LDAP Directory" />
 
 		<ldap:delete config-ref="LDAP_Configuration"
-			dn="#['ou=DevOpsGroup,' ++ attributes.queryParams.dn]" 
+			dn="#['ou=DevOpsGroup,' ++ attributes.queryParams.dn]"
 			doc:name="Delete Group Entry from LDAP Directory" />
 
 		<ee:transform doc:name="DataWeave to set Payload indicating flow completed">
@@ -517,7 +517,7 @@ Extended configuration parameters can be used for this to specify a custom trust
 The same Use Case 1 (above) can be used to execute this except for the configuration part of LDAP
 connector which should now use TLS configuration.
 
-Find below the XML configuration snippet of LDAP connector which uses TLS configuration and update
+Find below the XML configuration snippet of LDAP Connector which uses TLS configuration and update
 the Use Case 1 XML file (above) with it.
 
 [source,xml,linenums]
@@ -526,11 +526,11 @@ the Use Case 1 XML file (above) with it.
 <ldap:tls-connection authDn="${config.principal.dn}"
         authPassword="${config.password}" url="${config.url}">
     <ldap:extended-configurations>
-        <ldap:extended-configuration 
-        	key="org.mule.module.ldap.trustStorePath" 
+        <ldap:extended-configuration
+        	key="org.mule.module.ldap.trustStorePath"
         	value="the_path_to_trust_store_jks_file" />
-        <ldap:extended-configuration 
-        	key="org.mule.module.ldap.trustStorePassword" 
+        <ldap:extended-configuration
+        	key="org.mule.module.ldap.trustStorePassword"
         	value="changeit" />
     </ldap:extended-configurations>
 </ldap:tls-connection>


### PR DESCRIPTION
From docs-feedback, the doc was outdated and referring to the Connector configuration field as the Extension configuration.