### PR TITLE
Removing "Use the AWS Credentials Provider Chain in CloudHub"

### DIFF
--- a/modules/ROOT/pages/amazon/amazon-s3-connector-config-topics.adoc
+++ b/modules/ROOT/pages/amazon/amazon-s3-connector-config-topics.adoc
@@ -12,28 +12,6 @@ In the `Create Object` operation, set the `Content Length` to a value greater th
 
 To encrypt objects that you want to store in S3 buckets using customer managed master keys, specify a Customer Master Key ID in the `KMS Master Key` field in the `Create Object` configuration.
 
-== Use the AWS Credentials Provider Chain in CloudHub
-
-With the Default AWS Credentials Provider Chain, you can specify the access key and secret in the CloudHub environment:
-
-. Use the following configuration to prepare a Mule app.
-+
-[source,xml,linenums]
-----
- <s3:config name="Amazon_S3_S3_configuration" doc:name="Amazon S3 S3 configuration"
-    doc:id="DOC_ID" >
-  <s3:basic-connection accessKey="${aws.accessKeyId}" secretKey="${aws.secretKey}"
-    tryDefaultAWSCredentialsProviderChain="true"/>
- </s3:config>
-----
-+
-. Export this configuration to get a deployable zip archive.
-. Deploy to CloudHub and set the properties `aws.accessKeyId` and `aws.secretKey` through Runtime Manager > Settings > Properties.
-. Finish deploying and testing.
-
-[NOTE]
-The access key and secret key are not listed in the connector configuration. Instead, the correct values are used from the values specified in the settings.
-
 == Next Step
 
 After you understand how to configure a master key and provide credentials, you can try out the xref:amazon/amazon-s3-connector-examples.adoc[Example].


### PR DESCRIPTION
I understand that "AWS Credentials Provider Chain" doesn't work in Cloudhub (check this article: https://help.mulesoft.com/s/article/How-to-use-Default-AWS-Credentials-Provider-Chain-in-S3-connector, says "Please note, this is only possible in Runtime environments running the customers owned servers not in CloudHub, as customers don't have control over the environment of CloudHub workers."