### PR TITLE
Update object-store-connector.adoc

### DIFF
--- a/modules/ROOT/pages/object-store/object-store-connector.adoc
+++ b/modules/ROOT/pages/object-store/object-store-connector.adoc
@@ -30,7 +30,7 @@ By default, each Mule app has an Object Store that is persistent and always avai
 
 If you want to use the default Object Store, you can specify a `key` for the Object Store without selecting or creating an Object Store reference for the Object Store operation, and without specifying an `objectStore` attribute in the XML element for the Object Store component.
 
-Note that the Mule app is deployed into CloudHub workers through Anypoint Platform Runtime Manager, the contents of the Mule app's default Object Store are visible in Runtime Manager, within the Mule app's Application Data tab.
+Note that the Mule app is deployed into CloudHub workers through Anypoint Platform Runtime Manager, the contents of the Mule app's default Object Store are invisible in Runtime Manager, within the Mule app's Application Data tab.
 
 It is important to understand that the only Object Store displayed in the Runtime Manager Application Data tab is the default Object Store.
 


### PR DESCRIPTION
Incorrect: Note that the Mule app is deployed into CloudHub workers through Anypoint Platform Runtime Manager, the contents of the Mule app's default Object Store are visible in Runtime Manager, within the Mule app's Application Data tab.

Correct: Note that the Mule app is deployed into CloudHub workers through Anypoint Platform Runtime Manager, the contents of the Mule app's default Object Store are invisible in Runtime Manager, within the Mule app's Application Data tab.