### PR TITLE
SE-14973: Adds message to not use ssh-keygen's OpenSSH PKI for SFTP Connector

### DIFF
--- a/modules/ROOT/pages/sftp/sftp-documentation.adoc
+++ b/modules/ROOT/pages/sftp/sftp-documentation.adoc
@@ -7,7 +7,7 @@ Support Category: https://www.mulesoft.com/legal/versioning-back-support-policy#
 
 SFTP Connector v1.3
 
-Anypoint Connector for SFTP (SFTP Connector) provides access to files and folders on a SFTP server. 
+Anypoint Connector for SFTP (SFTP Connector) provides access to files and folders on a SFTP server.
 
 Release Notes: xref:release-notes::connector/connector-sftp.adoc[SFTP Connector Release Notes]
 
@@ -23,8 +23,8 @@ Release Notes: xref:release-notes::connector/connector-sftp.adoc[SFTP Connector 
 |Name | String | The name for this configuration. Connectors reference the configuration with this name. | | x
 | Connection a| <<config_connection, SFTP Connection>>
  | The connection types to provide to this configuration. | | x
-| (DEPRECATED) Default write encoding a| String |  This parameter is deprecated and not taken into account. |  | 
-| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to read. This allows a file write to complete before processing. If no value is provided, the check will not be performed. When enabled, Mule waits the specified time between calls and performs two size checks. If both checks return the same value, the file is ready to read. This attribute works in tandem with *Time Between Size Check Unit*. |  | 
+| (DEPRECATED) Default write encoding a| String |  This parameter is deprecated and not taken into account. |  |
+| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to read. This allows a file write to complete before processing. If no value is provided, the check will not be performed. When enabled, Mule waits the specified time between calls and performs two size checks. If both checks return the same value, the file is ready to read. This attribute works in tandem with *Time Between Size Check Unit*. |  |
 | Time Between Size Check Unit a| Enumeration, is one of:
 
 * NANOSECONDS
@@ -33,8 +33,8 @@ Release Notes: xref:release-notes::connector/connector-sftp.adoc[SFTP Connector 
 * SECONDS
 * MINUTES
 * HOURS
-* DAYS |  A TimeUnit that qualifies the *Time Between Size Check* attribute. + Defaults to `MILLISECONDS`. | `MILLISECONDS` | 
-| Expiration Policy a| <<ExpirationPolicy>> |  Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. Mule runtime engine purges the instances when it sees it fit. |  | 
+* DAYS |  A TimeUnit that qualifies the *Time Between Size Check* attribute. + Defaults to `MILLISECONDS`. | `MILLISECONDS` |
+| Expiration Policy a| <<ExpirationPolicy>> |  Configures the minimum amount of time that a dynamic configuration instance can remain idle before the runtime considers it eligible for expiration. This does not mean that the platform will expire the instance at the exact moment that it becomes eligible. Mule runtime engine purges the instances when it sees it fit. |  |
 |===
 
 ==== Connection Types
@@ -48,17 +48,17 @@ A file system provider that provides instances of SFTP file system from instance
 [%header,cols="20s,20a,35a,20a,5a"]
 |===
 | Name | Type | Description | Default Value | Required
-| Working Directory a| String |  The directory designated as the root of every relative path used with this connector. If not provided, it defaults to the remote server default. |  | 
+| Working Directory a| String |  The directory designated as the root of every relative path used with this connector. If not provided, it defaults to the remote server default. |  |
 | Preferred Authentication Methods a| Array of enumeration is one of:
 
 * GSSAPI_WITH_MIC
 * PUBLIC_KEY
 * KEYBOARD_INTERACTIVE
-* PASSWORD |  Set of authentication methods used by the SFTP client. Valid values are: `GSSAPI_WITH_MIC`, `PUBLIC_KEY`, `KEYBOARD_INTERACTIVE`, and `PASSWORD`. |  | 
-| Known Hosts File a| String |  If provided, the client validates the server's key against the one in the referenced file. If the server key doesn't match the one in the file, the connection will be aborted. |  | 
-| Sftp Proxy Config a| <<SftpProxyConfig>> |  If provided, a proxy will be used for the connection. |  | 
+* PASSWORD |  Set of authentication methods used by the SFTP client. Valid values are: `GSSAPI_WITH_MIC`, `PUBLIC_KEY`, `KEYBOARD_INTERACTIVE`, and `PASSWORD`. |  |
+| Known Hosts File a| String |  If provided, the client validates the server's key against the one in the referenced file. If the server key doesn't match the one in the file, the connection will be aborted. |  |
+| Sftp Proxy Config a| <<SftpProxyConfig>> |  If provided, a proxy will be used for the connection. |  |
 | Connection Timeout a| Number |  A scalar value representing the amount of time to wait before a connection attempt times out. This attribute works in tandem with *Connection Timeout Unit*. +
-Defaults to `10` |  `10` | 
+Defaults to `10` |  `10` |
 | Connection Timeout Unit a| Enumeration is one of:
 
 * NANOSECONDS
@@ -67,8 +67,8 @@ Defaults to `10` |  `10` |
 * SECONDS
 * MINUTES
 * HOURS
-* DAYS |  A time unit that qualifies the *Connection Timeout* attribute. + Defaults to `SECONDS` |  `SECONDS` | 
-| Response Timeout a| Number |  A scalar value representing the amount of time to wait before a request for data times out. This attribute works in tandem with *Response Timeout Unit*. + Defaults to `10` |  `10` | 
+* DAYS |  A time unit that qualifies the *Connection Timeout* attribute. + Defaults to `SECONDS` |  `SECONDS` |
+| Response Timeout a| Number |  A scalar value representing the amount of time to wait before a request for data times out. This attribute works in tandem with *Response Timeout Unit*. + Defaults to `10` |  `10` |
 | Response Timeout Unit a| Enumeration is one of:
 
 * NANOSECONDS
@@ -77,39 +77,39 @@ Defaults to `10` |  `10` |
 * SECONDS
 * MINUTES
 * HOURS
-* DAYS |  A TimeUnit that qualifies the *Response Timeout Unit* attribute. + Defaults to `SECONDS` |  `SECONDS` | 
+* DAYS |  A TimeUnit that qualifies the *Response Timeout Unit* attribute. + Defaults to `SECONDS` |  `SECONDS` |
 | Host a| String |  The FTP server host, such as `www.mulesoft.com`, `localhost`, or `192.168.0.1`, and so on. |  | x
-| Port a| Number |  The port number of the SFTP server to connect on. |  `22` | 
-| Username a| String |  Username for the FTP Server. Required if the server is authenticated. |  | 
-| Password a| String |  Password for the FTP Server. Required if the server is authenticated. |  | 
-| Passphrase a| String |  The passphrase (password) for the identity file if required. This parameter is ignored if identity file is not provided. |  | 
+| Port a| Number |  The port number of the SFTP server to connect on. |  `22` |
+| Username a| String |  Username for the FTP Server. Required if the server is authenticated. |  |
+| Password a| String |  Password for the FTP Server. Required if the server is authenticated. |  |
+| Passphrase a| String |  The passphrase (password) for the identity file if required. This parameter is ignored if identity file is not provided. |  |
 | Identity File a| String |  An identity file location for a PKI private key. +
-ssh-keygen's OpenSSH PKI format is not accepted. You can use argument "-m PEM". Please refer to https://www.openssh.com/txt/release-7.8. |  | 
+ssh-keygen's OpenSSH PKI format is not accepted. You can use argument "-m PEM". |  |
 | PRNG Algorithm a| Enumeration is one of:
 
 * AUTOSELECT
 * NativePRNG
 * SHA1PRNG
 * NativePRNGBlocking
-* NativePRNGNonBlocking |  The Pseudo Random Generator Algorithm to use. |  AUTOSELECT | 
-| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to `true`, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
-| Pooling Profile a| <<PoolingProfile>> |  Characteristics of the connection pool. |  | 
+* NativePRNGNonBlocking |  The Pseudo Random Generator Algorithm to use. |  AUTOSELECT |
+| Reconnection a| <<Reconnection>> |  When the application is deployed, a connectivity test is performed on all connectors. If set to `true`, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
+| Pooling Profile a| <<PoolingProfile>> |  Characteristics of the connection pool. |  |
 |===
 
 == Supported Operations
 
-* <<copy>> 
-* <<createDirectory>> 
-* <<delete>> 
-* <<list>> 
-* <<move>> 
-* <<read>> 
-* <<rename>> 
-* <<write>> 
+* <<copy>>
+* <<createDirectory>>
+* <<delete>>
+* <<list>>
+* <<move>>
+* <<read>>
+* <<rename>>
+* <<write>>
 
 === Associated Sources
 
-* <<listener>> 
+* <<listener>>
 
 
 == Operations
@@ -120,9 +120,9 @@ ssh-keygen's OpenSSH PKI format is not accepted. You can use argument "-m PEM". 
 
 Copies the file or directory specified in *Source Path* into the *Target Path*. The source path can be either a file or a directory. If it points to a directory, then it is copied recursively.
 
-If the target path doesn't exist, and neither does its parent, then a parent folder is created if *Create parent directories* is set to `true`. If *Create parent directories* is set to `false`, then an `SFTP:ILLEGAL_PATH` error is thrown. 
+If the target path doesn't exist, and neither does its parent, then a parent folder is created if *Create parent directories* is set to `true`. If *Create parent directories* is set to `false`, then an `SFTP:ILLEGAL_PATH` error is thrown.
 
-If *Overwrite* is set to `true` and the target file already exists, then the target file is overwritten. Otherwise, an `SFTP:FILE_ALREADY_EXISTS` error is thrown. 
+If *Overwrite* is set to `true` and the target file already exists, then the target file is overwritten. Otherwise, an `SFTP:FILE_ALREADY_EXISTS` error is thrown.
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]
@@ -131,22 +131,22 @@ If *Overwrite* is set to `true` and the target file already exists, then the tar
 | Configuration | String | The name of the configuration to use. | | x
 | Source Path a| String |  The path to the file to copy. |  | x
 | Target Path a| String |  The target directory for where to copy the file. |  | x
-| Create Parent Directories a| Boolean |  Whether or not to attempt to create parent directories if they don't exist. |  true | 
-| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  false | 
-| Rename To a| String |  Rename the copied file. If this value is not provided, the original file name is kept. |  | 
+| Create Parent Directories a| Boolean |  Whether or not to attempt to create parent directories if they don't exist. |  true |
+| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  false |
+| Rename To a| String |  Rename the copied file. If this value is not provided, the original file name is kept. |  |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED 
-* SFTP:ILLEGAL_PATH 
-* SFTP:FILE_ALREADY_EXISTS 
-* SFTP:CONNECTIVITY 
+* SFTP:RETRY_EXHAUSTED
+* SFTP:ILLEGAL_PATH
+* SFTP:FILE_ALREADY_EXISTS
+* SFTP:CONNECTIVITY
 
 
 [[createDirectory]]
@@ -164,20 +164,20 @@ Creates a new directory using the value in the *Directory Path* field.
 | Configuration | String | The name of the configuration to use. | | x
 | Directory Path a| String |  The new directory's name. |  | x
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
 
-* SFTP:RETRY_EXHAUSTED 
-* SFTP:ILLEGAL_PATH 
-* SFTP:ACCESS_DENIED 
-* SFTP:FILE_ALREADY_EXISTS 
-* SFTP:CONNECTIVITY 
+* SFTP:RETRY_EXHAUSTED
+* SFTP:ILLEGAL_PATH
+* SFTP:ACCESS_DENIED
+* SFTP:FILE_ALREADY_EXISTS
+* SFTP:CONNECTIVITY
 
 
 [[delete]]
@@ -194,20 +194,20 @@ Deletes the file that the path field points to, provided that the file is not lo
 | Configuration | String | The name of the configuration to use. | | x
 | Path a| String |  The path to the file to delete. |  | x
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 
 === For Configurations
 
-* <<config>> 
+* <<config>>
 
 ==== Throws
 
-* SFTP:RETRY_EXHAUSTED 
-* SFTP:ILLEGAL_PATH 
-* SFTP:ACCESS_DENIED 
-* SFTP:CONNECTIVITY 
+* SFTP:RETRY_EXHAUSTED
+* SFTP:ILLEGAL_PATH
+* SFTP:ACCESS_DENIED
+* SFTP:CONNECTIVITY
 
 
 [[list]]
@@ -215,9 +215,9 @@ Deletes the file that the path field points to, provided that the file is not lo
 `<sftp:list>`
 
 
-Lists all the files in the *Directory Path* depending on the rules in the File Matching Rules field. 
+Lists all the files in the *Directory Path* depending on the rules in the File Matching Rules field.
 
-If the listing encounters a directory, the output list will include its contents, depending on the value of the *Recursive* field. 
+If the listing encounters a directory, the output list will include its contents, depending on the value of the *Recursive* field.
 
 If *Recursive* is set to the `true` value, but a found directory is rejected by the rules in the *File Matching Rules* field, then recursion does not occur in the directory.
 
@@ -228,9 +228,9 @@ If *Recursive* is set to the `true` value, but a found directory is rejected by 
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Directory Path a| String | The directory path to list. |  | x
-| Recursive a| Boolean |  Whether to include the contents of subdirectories. Defaults to `false`. | `false` | 
-| File Matching Rules a| <<matcher>> |  A matcher used to filter the output list. |  | 
-| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to read. |  | 
+| Recursive a| Boolean |  Whether to include the contents of subdirectories. Defaults to `false`. | `false` |
+| File Matching Rules a| <<matcher>> |  A matcher used to filter the output list. |  |
+| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to read. |  |
 | Time Between Size Check Unit a| Enumeration is one of:
 
 * NANOSECONDS
@@ -239,14 +239,14 @@ If *Recursive* is set to the `true` value, but a found directory is rejected by 
 * SECONDS
 * MINUTES
 * HOURS
-* DAYS |  Time unit to use in the wait time between size checks. |  | 
+* DAYS |  Time unit to use in the wait time between size checks. |  |
 | Streaming Strategy a| * <<repeatable-in-memory-iterable>>
 * <<repeatable-file-store-iterable>>
-* <<non-repeatable-iterable>> |  Configure whether to use repeatable streams. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` | 
+* <<non-repeatable-iterable>> |  Configure whether to use repeatable streams. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  `#[payload]` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -256,11 +256,11 @@ If *Recursive* is set to the `true` value, but a found directory is rejected by 
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* SFTP:ILLEGAL_PATH 
-* SFTP:ACCESS_DENIED 
+* SFTP:ILLEGAL_PATH
+* SFTP:ACCESS_DENIED
 
 
 [[move]]
@@ -270,9 +270,9 @@ If *Recursive* is set to the `true` value, but a found directory is rejected by 
 
 Moves the file or directory from the *Source Path* into the *Target Path*. The source path can be either a file or a directory. If it points to a directory, then it will be moved recursively.
 
-If the target path doesn't exist, and neither does its parent, then a parent folder is created if *Create parent directories* is set to `true`. If *Create parent directories*  is set to `false`, then an `SFTP:ILLEGAL_PATH` error is thrown. 
+If the target path doesn't exist, and neither does its parent, then a parent folder is created if *Create parent directories* is set to `true`. If *Create parent directories*  is set to `false`, then an `SFTP:ILLEGAL_PATH` error is thrown.
 
-If the target file already exists, then it will be overwritten if *Overwrite* is set to `true`. If *Overwrite* is set to `false`, an `SFTP:FILE_ALREADY_EXISTS` error will be thrown. 
+If the target file already exists, then it will be overwritten if *Overwrite* is set to `true`. If *Overwrite* is set to `false`, an `SFTP:FILE_ALREADY_EXISTS` error will be thrown.
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]
@@ -281,22 +281,22 @@ If the target file already exists, then it will be overwritten if *Overwrite* is
 | Configuration | String | The name of the configuration to use. | | x
 | Source Path a| String |  The path to the file to copy. |  | x
 | Target Path a| String |  The target directory. |  | x
-| Create Parent Directories a| Boolean |  Whether or not to attempt to create any parent directories that don't exist. |  `true` | 
-| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  `false` | 
-| Rename To a| String |  Name of the moved file. If a value is not provided, the original file name is kept. |  | 
+| Create Parent Directories a| Boolean |  Whether or not to attempt to create any parent directories that don't exist. |  `true` |
+| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  `false` |
+| Rename To a| String |  Name of the moved file. If a value is not provided, the original file name is kept. |  |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 
 ==== For Configurations.
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED 
-* SFTP:ILLEGAL_PATH 
-* SFTP:FILE_ALREADY_EXISTS 
-* SFTP:CONNECTIVITY 
+* SFTP:RETRY_EXHAUSTED
+* SFTP:ILLEGAL_PATH
+* SFTP:FILE_ALREADY_EXISTS
+* SFTP:CONNECTIVITY
 
 
 [[read]]
@@ -304,9 +304,9 @@ If the target file already exists, then it will be overwritten if *Overwrite* is
 `<sftp:read>`
 
 
-Obtains the content and metadata of a file at a given path. The operation itself returns a message whose payload is an input stream with the file's content, and the metadata is represented as an `SftpFileAttributes` object that's placed as the message `Message#getAttributes()` attributes. 
+Obtains the content and metadata of a file at a given path. The operation itself returns a message whose payload is an input stream with the file's content, and the metadata is represented as an `SftpFileAttributes` object that's placed as the message `Message#getAttributes()` attributes.
 
-If the lock parameter is set to `true`, then a file system level lock is placed on the file until the input stream this operation returns is closed or fully consumed. Because the lock is provided by the host file system, its behavior might change depending on the mounted drive and the operation system on which Mule is running. Take that into consideration before relying on this lock. 
+If the lock parameter is set to `true`, then a file system level lock is placed on the file until the input stream this operation returns is closed or fully consumed. Because the lock is provided by the host file system, its behavior might change depending on the mounted drive and the operation system on which Mule is running. Take that into consideration before relying on this lock.
 
 This method also makes a best effort to determine the MIME type of the file being read by using the file's extension to make an educated guess. You can also use the output *Encoding* and output *MIME Type* optional parameters to force the encoding and MIME type.
 
@@ -317,8 +317,8 @@ This method also makes a best effort to determine the MIME type of the file bein
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | File Path a| String |  The path to the file to read.|  | x
-| Lock a| Boolean |  Whether or not to lock the file. Defaults to `false`. |  `false` | 
-| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to read. |  | 
+| Lock a| Boolean |  Whether or not to lock the file. Defaults to `false`. |  `false` |
+| Time Between Size Check a| Number |  Wait time between size checks to determine if a file is ready to read. |  |
 | Time Between Size Check Unit a| Enumeration is one of:
 
 * NANOSECONDS
@@ -327,16 +327,16 @@ This method also makes a best effort to determine the MIME type of the file bein
 * SECONDS
 * MINUTES
 * HOURS
-* DAYS |  Time unit to use in the wait time between size checks. |  | 
-| Output Mime Type a| String |  The MIME type of the payload that this operation outputs. |  | 
-| Output Encoding a| String |  The encoding of the payload that this operation outputs. |  | 
+* DAYS |  Time unit to use in the wait time between size checks. |  |
+| Output Mime Type a| String |  The MIME type of the payload that this operation outputs. |  |
+| Output Encoding a| String |  The encoding of the payload that this operation outputs. |  |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* <<non-repeatable-stream>> |  Configure whether to use repeatable streams. |  | 
-| Target Variable a| String |  The name of a variable to store the operation's output. |  | 
-| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  #[payload] | 
+* <<non-repeatable-stream>> |  Configure whether to use repeatable streams. |  |
+| Target Variable a| String |  The name of a variable to store the operation's output. |  |
+| Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable. |  #[payload] |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 ==== Output
@@ -347,14 +347,14 @@ This method also makes a best effort to determine the MIME type of the file bein
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* SFTP:FILE_LOCK 
-* SFTP:RETRY_EXHAUSTED 
-* SFTP:ILLEGAL_PATH 
-* SFTP:ACCESS_DENIED 
-* SFTP:CONNECTIVITY 
+* SFTP:FILE_LOCK
+* SFTP:RETRY_EXHAUSTED
+* SFTP:ILLEGAL_PATH
+* SFTP:ACCESS_DENIED
+* SFTP:CONNECTIVITY
 
 
 [[rename]]
@@ -371,21 +371,21 @@ Renames the file to which the path points to the value provided in the *New Name
 | Configuration | String | The name of the configuration to use. | | x
 | Path a| String |  The path to the file to rename. |  | x
 | New Name a| String |  The file's new name. |  | x
-| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  `false` | 
+| Overwrite a| Boolean |  Whether or not to overwrite the file if the target destination already exists. |  `false` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
-* SFTP:RETRY_EXHAUSTED 
-* SFTP:ILLEGAL_PATH 
-* SFTP:ACCESS_DENIED 
-* SFTP:FILE_ALREADY_EXISTS 
-* SFTP:CONNECTIVITY 
+* SFTP:RETRY_EXHAUSTED
+* SFTP:ILLEGAL_PATH
+* SFTP:ACCESS_DENIED
+* SFTP:FILE_ALREADY_EXISTS
+* SFTP:CONNECTIVITY
 
 
 [[write]]
@@ -393,9 +393,9 @@ Renames the file to which the path points to the value provided in the *New Name
 `<sftp:write>`
 
 
-Writes the content into the file the path points to. 
+Writes the content into the file the path points to.
 
-If the directory to which the file is attempting to be written doesn't exist, then the operation will either throw an `SFTP:ILLEGAL_PATH` error, or create a new folder, depending on the value of *Create parent directories*. If the file already exists, then the behavior depends on the supplied mode. 
+If the directory to which the file is attempting to be written doesn't exist, then the operation will either throw an `SFTP:ILLEGAL_PATH` error, or create a new folder, depending on the value of *Create parent directories*. If the file already exists, then the behavior depends on the supplied mode.
 
 This operation also supports locking depending on the value of the lock argument, and follows the same rules and considerations as described in the read operation.
 
@@ -405,31 +405,31 @@ This operation also supports locking depending on the value of the lock argument
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Path a| String |  The path of the file to write. |  | x
-| Content a| Binary |  The content to write into the file. Defaults to the current Message payload. |  `#[payload]` | 
-| (DEPRECATED) Encoding  a| String |  This parameter is deprecated and does nothing if configured. |  | 
-| Create Parent Directories a| Boolean |  Whether or not to attempt to create any parent directories that don't exist. |  `true` | 
-| Lock a| Boolean |  Whether or not to lock the file. Defaults to `false`. |  `false` | 
+| Content a| Binary |  The content to write into the file. Defaults to the current Message payload. |  `#[payload]` |
+| (DEPRECATED) Encoding  a| String |  This parameter is deprecated and does nothing if configured. |  |
+| Create Parent Directories a| Boolean |  Whether or not to attempt to create any parent directories that don't exist. |  `true` |
+| Lock a| Boolean |  Whether or not to lock the file. Defaults to `false`. |  `false` |
 | Write Mode a| Enumeration is one of:
 
 * OVERWRITE
 * APPEND
-* CREATE_NEW |  A `FileWriteMode`. Defaults to `OVERWRITE` |  `OVERWRITE` | 
+* CREATE_NEW |  A `FileWriteMode`. Defaults to `OVERWRITE` |  `OVERWRITE` |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
 |===
 
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 ==== Throws
 * SFTP:FILE_LOCK
-* SFTP:RETRY_EXHAUSTED 
-* SFTP:ILLEGAL_PATH 
-* SFTP:ACCESS_DENIED 
-* SFTP:ILLEGAL_CONTENT 
-* SFTP:FILE_ALREADY_EXISTS 
-* SFTP:CONNECTIVITY 
+* SFTP:RETRY_EXHAUSTED
+* SFTP:ILLEGAL_PATH
+* SFTP:ACCESS_DENIED
+* SFTP:ILLEGAL_CONTENT
+* SFTP:FILE_ALREADY_EXISTS
+* SFTP:CONNECTIVITY
 
 
 == Sources
@@ -438,9 +438,9 @@ This operation also supports locking depending on the value of the lock argument
 === On New or Updated File
 `<sftp:listener>`
 
-Polls a directory and looks for files that have been created in it. One message is generated for each file that is found. 
+Polls a directory and looks for files that have been created in it. One message is generated for each file that is found.
 
-The key part of this functionality is how to determine that a file is actually new. There are three strategies for that: 
+The key part of this functionality is how to determine that a file is actually new. There are three strategies for that:
 
 * Set the *Auto delete* parameter to `true` to delete each file after it is processed, which causes all files obtained in the next poll to be necessarily new.
 * Set the *Move to directory* parameter to move each file to a different directory after it is processed, which achieves the same effect as *Auto delete* but without losing the file.
@@ -453,12 +453,12 @@ You can also use a matcher for additional filtering of files.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Directory a| String |  The directory in which polled files are contained. |  | 
-| Recursive a| Boolean |  Whether or not to also poll files contained in sub directories. |  true | 
-| Matcher a| <<matcher>> |  A matcher used to filter events on files that do not meet the file matching criteria. |  | 
-| Watermark Enabled a| Boolean |  Controls whether or not to do watermarking, and if so, if the watermark should consider the file's modification or creation timestamps. |  false | 
+| Directory a| String |  The directory in which polled files are contained. |  |
+| Recursive a| Boolean |  Whether or not to also poll files contained in sub directories. |  true |
+| Matcher a| <<matcher>> |  A matcher used to filter events on files that do not meet the file matching criteria. |  |
+| Watermark Enabled a| Boolean |  Controls whether or not to do watermarking, and if so, if the watermark should consider the file's modification or creation timestamps. |  false |
 | Time Between Size Check a| Number |  Wait time (in milliseconds) between size checks to determine if a file is ready to read. This allows a file write to complete before processing. When enabled, Mule performs two size checks, waiting the specified time between calls. If both checks return the same value, the file is ready to read. +
-You can disable this feature by omitting a value.  |  | 
+You can disable this feature by omitting a value.  |  |
 | Time Between Size Check Unit a| Enumeration is one of:
 
 * NANOSECONDS
@@ -467,21 +467,21 @@ You can disable this feature by omitting a value.  |  |
 * SECONDS
 * MINUTES
 * HOURS
-* DAYS |  A TimeUnit which qualifies the *Time between size check* attribute. |  | 
-| Output Mime Type a| String |  The MIME type of the payload that this operation outputs. |  | 
-| Output Encoding a| String |  The encoding of the payload that this operation outputs. |  | 
-| Primary Node Only a| Boolean |  Whether this source should be executed only on the primary node when running in a cluster. |  | 
+* DAYS |  A TimeUnit which qualifies the *Time between size check* attribute. |  |
+| Output Mime Type a| String |  The MIME type of the payload that this operation outputs. |  |
+| Output Encoding a| String |  The encoding of the payload that this operation outputs. |  |
+| Primary Node Only a| Boolean |  Whether this source should be executed only on the primary node when running in a cluster. |  |
 | Scheduling Strategy a| <<scheduling-strategy>> |  Configures the scheduler that triggers the polling. |  | x
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>
 * <<repeatable-file-store-stream>>
-* <<non-repeatable-stream>> |  Configure whether to use repeatable streams. |  | 
-| Redelivery Policy a| <<RedeliveryPolicy>> |  Defines a policy for processing the redelivery of the same message. |  | 
+* <<non-repeatable-stream>> |  Configure whether to use repeatable streams. |  |
+| Redelivery Policy a| <<RedeliveryPolicy>> |  Defines a policy for processing the redelivery of the same message. |  |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  | 
-| Auto Delete a| Boolean |  Whether to delete each file after processing. |  `false` | 
-| Move To Directory a| String |  If provided, each processed file will be moved to a directory that is pointed to by this path. |  | 
-| Rename To a| String |  This parameter works in tandem with *Move to directory*. Use this parameter to enter the name of the directory under which to move the file. Do not set this parameter if *Move to directory* hasn't also been set. |  | 
-| Apply Post Action When Failed a| Boolean |  Specifies whether any of the post actions (*Auto delete* and *Move to directory*) should also be applied in case the file fails to be processed. If set to `false`, no failed files will be moved or deleted. |  `true` | 
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. |  |
+| Auto Delete a| Boolean |  Whether to delete each file after processing. |  `false` |
+| Move To Directory a| String |  If provided, each processed file will be moved to a directory that is pointed to by this path. |  |
+| Rename To a| String |  This parameter works in tandem with *Move to directory*. Use this parameter to enter the name of the directory under which to move the file. Do not set this parameter if *Move to directory* hasn't also been set. |  |
+| Apply Post Action When Failed a| Boolean |  Specifies whether any of the post actions (*Auto delete* and *Move to directory*) should also be applied in case the file fails to be processed. If set to `false`, no failed files will be moved or deleted. |  `true` |
 |===
 
 ==== Output
@@ -492,7 +492,7 @@ You can disable this feature by omitting a value.  |  |
 |===
 
 === For Configurations
-* <<config>> 
+* <<config>>
 
 
 == Types
@@ -504,8 +504,8 @@ You can disable this feature by omitting a value.  |  |
 | Field | Type | Description | Default Value | Required
 | Host a| String |  |  | x
 | Port a| Number |  |  | x
-| Username a| String |  |  | 
-| Password a| String |  |  | 
+| Username a| String |  |  |
+| Password a| String |  |  |
 | Protocol a| Enumeration is of:
 
 * HTTP
@@ -519,9 +519,9 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to `true`, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  | 
+| Fails Deployment a| Boolean | When the application is deployed, a connectivity test is performed on all connectors. If set to `true`, deployment fails if the test doesn't pass after exhausting the associated reconnection strategy. |  |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> | The reconnection strategy to use. |  | 
+* <<reconnect-forever>> | The reconnection strategy to use. |  |
 |===
 
 [[reconnect]]
@@ -552,29 +552,29 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Active a| Number | Controls the maximum number of Mule components that can be active at one time. When set to a negative value, there is no limit to the number of components that can be active at one time. When *Max active* is exceeded, the pool is exhausted. |  | 
-| Max Idle a| Number | Controls the maximum number of Mule components that can sit idle in the pool at any one time. When set to a negative value, there is no limit to the number of Mule components that can be idle at one time. |  | 
-| Max Wait a| Number | Specifies the number of milliseconds to wait for a pooled component to become available when the pool is exhausted and the *Exhausted action* is set to `WHEN_EXHAUSTED_WAIT`. |  | 
-| Min Eviction Millis a| Number | Determines the minimum amount of time an object can sit idle in the pool before it is eligible for eviction. When non-positive, no objects will be evicted from the pool due to idle time alone. |  | 
-| Eviction Check Interval Millis a| Number | Specifies the number of milliseconds between runs of the object evictor. When non-positive, no object evictor is executed. |  | 
+| Max Active a| Number | Controls the maximum number of Mule components that can be active at one time. When set to a negative value, there is no limit to the number of components that can be active at one time. When *Max active* is exceeded, the pool is exhausted. |  |
+| Max Idle a| Number | Controls the maximum number of Mule components that can sit idle in the pool at any one time. When set to a negative value, there is no limit to the number of Mule components that can be idle at one time. |  |
+| Max Wait a| Number | Specifies the number of milliseconds to wait for a pooled component to become available when the pool is exhausted and the *Exhausted action* is set to `WHEN_EXHAUSTED_WAIT`. |  |
+| Min Eviction Millis a| Number | Determines the minimum amount of time an object can sit idle in the pool before it is eligible for eviction. When non-positive, no objects will be evicted from the pool due to idle time alone. |  |
+| Eviction Check Interval Millis a| Number | Specifies the number of milliseconds between runs of the object evictor. When non-positive, no object evictor is executed. |  |
 | Exhausted Action a| Enumeration is one of:
 
 * WHEN_EXHAUSTED_GROW
 * WHEN_EXHAUSTED_WAIT
-* WHEN_EXHAUSTED_FAIL a| Specifies the behavior of the Mule component pool when the pool is exhausted. Possible values are: 
+* WHEN_EXHAUSTED_FAIL a| Specifies the behavior of the Mule component pool when the pool is exhausted. Possible values are:
 
-* `WHEN_EXHAUSTED_FAIL`, which will throw a `NoSuchElementException`. * `WHEN_EXHAUSTED_WAIT`, which will block by invoking `Object.wait(long)` until a new or idle object is available. 
-* `WHEN_EXHAUSTED_GROW`, which will create a new Mule instance and return it, essentially making `maxActive` meaningless. If a positive `maxWait` value is supplied, it will block for, at most, the specified number of milliseconds, after which a `NoSuchElementException` will be thrown. If `maxThreadWait` is a negative value, it will block indefinitely. |  | 
+* `WHEN_EXHAUSTED_FAIL`, which will throw a `NoSuchElementException`. * `WHEN_EXHAUSTED_WAIT`, which will block by invoking `Object.wait(long)` until a new or idle object is available.
+* `WHEN_EXHAUSTED_GROW`, which will create a new Mule instance and return it, essentially making `maxActive` meaningless. If a positive `maxWait` value is supplied, it will block for, at most, the specified number of milliseconds, after which a `NoSuchElementException` will be thrown. If `maxThreadWait` is a negative value, it will block indefinitely. |  |
 | Initialisation Policy a| Enumeration is one of:
 
 * INITIALISE_NONE
 * INITIALISE_ONE
-* INITIALISE_ALL a| Determines how components in a pool should be initialized. The possible values are: 
+* INITIALISE_ALL a| Determines how components in a pool should be initialized. The possible values are:
 
 * INITIALISE_NONE, which means no components will be loaded into the pool at startup.
-* INITIALISE_ONE, which will load one initial component into the pool at startup. 
-* INITIALISE_ALL, which will load all components in the pool at startup. |  | 
-| Disabled a| Boolean | Whether to disable pooling. |  | 
+* INITIALISE_ONE, which will load one initial component into the pool at startup.
+* INITIALISE_ALL, which will load all components in the pool at startup. |  |
+| Disabled a| Boolean | Whether to disable pooling. |  |
 |===
 
 [[ExpirationPolicy]]
@@ -583,7 +583,7 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Idle Time a| Number | A scalar time value for the maximum amount of time a dynamic configuration instance should be allowed to be idle before it's considered eligible for expiration. |  | 
+| Max Idle Time a| Number | A scalar time value for the maximum amount of time a dynamic configuration instance should be allowed to be idle before it's considered eligible for expiration. |  |
 | Time Unit a| Enumeration is one of:
 
 * NANOSECONDS
@@ -592,7 +592,7 @@ You can disable this feature by omitting a value.  |  |
 * SECONDS
 * MINUTES
 * HOURS
-* DAYS | A time unit that qualifies the *Max idle time* attribute. |  | 
+* DAYS | A time unit that qualifies the *Max idle time* attribute. |  |
 |===
 
 [[SftpFileAttributes]]
@@ -603,9 +603,9 @@ You can disable this feature by omitting a value.  |  |
 | Field | Type | Description | Default Value | Required
 | Timestamp a| DateTime |  |  | x
 | Size a| Number |  |  | x
-| Regular Size a| Boolean |  | false | 
-| Directory a| Boolean |  | false | 
-| Symbolic Link a| Boolean |  | false | 
+| Regular Size a| Boolean |  | false |
+| Directory a| Boolean |  | false |
+| Symbolic Link a| Boolean |  | false |
 | Path a| String |  |  | x
 | File Name a| String |  |  | x
 |===
@@ -616,10 +616,10 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Timestamp Since a| DateTime | Files created before this date are rejected. |  | 
-| Timestamp Until a| DateTime | Files created after this date are rejected. |  | 
-| Not Updated In The Last a| Number | Minimum time that should pass since a file was last updated to not be rejected. This attribute works in tandem with *Time unit*. |  | 
-| Updated In The Last a| Number | Maximum time that should pass from when a file was last updated to not be rejected. This attribute works in tandem with *Time unit*. |  | 
+| Timestamp Since a| DateTime | Files created before this date are rejected. |  |
+| Timestamp Until a| DateTime | Files created after this date are rejected. |  |
+| Not Updated In The Last a| Number | Minimum time that should pass since a file was last updated to not be rejected. This attribute works in tandem with *Time unit*. |  |
+| Updated In The Last a| Number | Maximum time that should pass from when a file was last updated to not be rejected. This attribute works in tandem with *Time unit*. |  |
 | Time Unit a| Enumeration is one of:
 
 * NANOSECONDS
@@ -630,26 +630,26 @@ You can disable this feature by omitting a value.  |  |
 * HOURS
 * DAYS | A *Not updated in the last* attributes.
  +
- Defaults to MILLISECONDS | MILLISECONDS | 
-| Filename Pattern a| String |  |  | 
-| Path Pattern a| String |  |  | 
+ Defaults to MILLISECONDS | MILLISECONDS |
+| Filename Pattern a| String |  |  |
+| Path Pattern a| String |  |  |
 | Directories a| Enumeration is one of:
 
 * REQUIRE
 * INCLUDE
-* EXCLUDE |  | INCLUDE | 
+* EXCLUDE |  | INCLUDE |
 | Regular Files a| Enumeration is one of:
 
 * REQUIRE
 * INCLUDE
-* EXCLUDE |  | INCLUDE | 
+* EXCLUDE |  | INCLUDE |
 | Sym Links a| Enumeration is one of:
 
 * REQUIRE
 * INCLUDE
-* EXCLUDE |  | INCLUDE | 
-| Min Size a| Number |  |  | 
-| Max Size a| Number |  |  | 
+* EXCLUDE |  | INCLUDE |
+| Min Size a| Number |  |  |
+| Max Size a| Number |  |  |
 |===
 
 [[repeatable-in-memory-stream]]
@@ -658,15 +658,15 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Initial Buffer Size a| Number | This is the amount of memory to allocate to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then it will be expanded according to the *Buffer size increment* attribute, with an upper limit of *Max in memory size*. |  | 
-| Buffer Size Increment a| Number | This is by how much the buffer size will be expanded if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, and that a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised when the buffer gets full. |  | 
-| Max Buffer Size a| Number | This is the maximum amount of memory to use. If more than the specified maximum is used, then a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised. A value lower or equal to zero means no limit. |  | 
+| Initial Buffer Size a| Number | This is the amount of memory to allocate to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then it will be expanded according to the *Buffer size increment* attribute, with an upper limit of *Max in memory size*. |  |
+| Buffer Size Increment a| Number | This is by how much the buffer size will be expanded if it exceeds its initial size. Setting a value of zero or lower means that the buffer should not expand, and that a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised when the buffer gets full. |  |
+| Max Buffer Size a| Number | This is the maximum amount of memory to use. If more than the specified maximum is used, then a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised. A value lower or equal to zero means no limit. |  |
 | Buffer Unit a| Enumeration is one of:
 
 * BYTE
 * KB
 * MB
-* GB | The unit in which all these attributes are expressed. |  | 
+* GB | The unit in which all these attributes are expressed. |  |
 |===
 
 [[repeatable-file-store-stream]]
@@ -675,13 +675,13 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Max In Memory Size a| Number | Defines the maximum memory that the stream should use to keep data in memory. If more than that is consumed then content is buffered on the disk.  |  | 
+| Max In Memory Size a| Number | Defines the maximum memory that the stream should use to keep data in memory. If more than that is consumed then content is buffered on the disk.  |  |
 | Buffer Unit a| Enumeration, one of:
 
 * BYTE
 * KB
 * MB
-* GB | The unit in which maxInMemorySize is expressed |  | 
+* GB | The unit in which maxInMemorySize is expressed |  |
 |===
 
 [[RedeliveryPolicy]]
@@ -690,11 +690,11 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Max Redelivery Count a| Number | The maximum number of times a message can be redelivered and processed unsuccessfully before triggering process-failed-message |  | 
-| Use Secure Hash a| Boolean | Whether to use a secure hash algorithm to identify a redelivered message |  | 
-| Message Digest Algorithm a| String | The secure hashing algorithm to use. If not set, the default is `SHA-256`. |  | 
-| Id Expression a| String | Defines one or more expressions to use to determine when a message has been redelivered. This property may only be set if useSecureHash is false. |  | 
-| Object Store a| <<ObjectStore>> | The object store where the redelivery counter for each message will be stored. |  | 
+| Max Redelivery Count a| Number | The maximum number of times a message can be redelivered and processed unsuccessfully before triggering process-failed-message |  |
+| Use Secure Hash a| Boolean | Whether to use a secure hash algorithm to identify a redelivered message |  |
+| Message Digest Algorithm a| String | The secure hashing algorithm to use. If not set, the default is `SHA-256`. |  |
+| Id Expression a| String | Defines one or more expressions to use to determine when a message has been redelivered. This property may only be set if useSecureHash is false. |  |
+| Object Store a| <<ObjectStore>> | The object store where the redelivery counter for each message will be stored. |  |
 |===
 
 [[repeatable-in-memory-iterable]]
@@ -703,9 +703,9 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Initial Buffer Size a| Number | This is the number of instances initially allowed to be kept in memory in order to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then it will be expanded according to the *Buffer size increment* attribute, with an upper limit of *Max in memory size*. Default value is 100 instances. |  | 
-| Buffer Size Increment a| Number | How much the buffer size will expand if it exceeds its initial specified size. Setting a value of zero or lower means that the buffer should not expand, and that a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised when the buffer gets full. Default value is 100 instances. |  | 
-| Max in Memory Instances a| Number | This is the maximum amount of memory to use. If more than the maximum amount is used, then a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised. A value lower or equal to zero means no limit. |  | 
+| Initial Buffer Size a| Number | This is the number of instances initially allowed to be kept in memory in order to consume the stream and provide random access to it. If the stream contains more data than can fit into this buffer, then it will be expanded according to the *Buffer size increment* attribute, with an upper limit of *Max in memory size*. Default value is 100 instances. |  |
+| Buffer Size Increment a| Number | How much the buffer size will expand if it exceeds its initial specified size. Setting a value of zero or lower means that the buffer should not expand, and that a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised when the buffer gets full. Default value is 100 instances. |  |
+| Max in Memory Instances a| Number | This is the maximum amount of memory to use. If more than the maximum amount is used, then a `STREAM_MAXIMUM_SIZE_EXCEEDED` error will be raised. A value lower or equal to zero means no limit. |  |
 |===
 
 
@@ -715,7 +715,7 @@ You can disable this feature by omitting a value.  |  |
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| In Memory Objects a| Number | The maximum number of instances to keep in memory. If more than the maximum is required, content starts to buffer to the disk. |  | 
+| In Memory Objects a| Number | The maximum number of instances to keep in memory. If more than the maximum is required, content starts to buffer to the disk. |  |
 |===
 
 == See Also

--- a/modules/ROOT/pages/sftp/sftp-documentation.adoc
+++ b/modules/ROOT/pages/sftp/sftp-documentation.adoc
@@ -83,7 +83,8 @@ Defaults to `10` |  `10` |
 | Username a| String |  Username for the FTP Server. Required if the server is authenticated. |  | 
 | Password a| String |  Password for the FTP Server. Required if the server is authenticated. |  | 
 | Passphrase a| String |  The passphrase (password) for the identity file if required. This parameter is ignored if identity file is not provided. |  | 
-| Identity File a| String |  An identity file location for a PKI private key. |  | 
+| Identity File a| String |  An identity file location for a PKI private key. +
+ssh-keygen's OpenSSH PKI format is not accepted. You can use argument "-m PEM". Please refer to https://www.openssh.com/txt/release-7.8. |  | 
 | PRNG Algorithm a| Enumeration is one of:
 
 * AUTOSELECT


### PR DESCRIPTION
Since we use JSCH to provide connectivity, ssh-keygen's OpenSSH PKIs are not accepted.
This library limitation will be addressed in Connector's version 2.