### PR TITLE
Updated migration guide for kafka connector

### DIFF
--- a/kafka/4.1/modules/ROOT/pages/kafka-connector-upgrade-migrate.adoc
+++ b/kafka/4.1/modules/ROOT/pages/kafka-connector-upgrade-migrate.adoc
@@ -43,8 +43,8 @@ The user must manually acknowledge the message within the flow.
 Same as the AUTO mode, but the commit is made asynchronously, which can result in duplicate records.
 ** IMMEDIATE +
 Mule automatically acknowledges the message upon receipt.
-* There is now one plaintext connection type that supports transactions.
-
+* There is now one plaintext connection type that supports transactions. +
+* In the version 3.x of the connector users were able to add a customizable set of configuration properties that could be set in a key/value format related to connections but in this way we had no control over what the user could set in those properties so, in the version 4.x of the connector this feature was removed and the connector has a restricted set of connection types were the users can set all the required properties.
 
 [[changed_sources]]
 == Changed Sources


### PR DESCRIPTION
Added information regarding a removed feature from the previous kafka version.