### PR TITLE
fixed incorrect OAuth grant type

### DIFF
--- a/http/1.5/modules/ROOT/pages/http-authentication.adoc
+++ b/http/1.5/modules/ROOT/pages/http-authentication.adoc
@@ -881,7 +881,7 @@ Client credentials grant type is meant to be used by a CA to grant access to an 
 
 === OAuth2 - Studio Visual Editor
 
-. In Studio, select the HTTP Request Configuration global element where you want to use the OAuth authorization code grant type.
+. In Studio, select the HTTP Request Configuration global element where you want to use the OAuth client credentials grant type.
 . In *Authentication*, select *Client credentials grant type*.
 . Fill in the following fields:
 +


### PR DESCRIPTION
Should be "client credentials" instead of "authorization code" grant type.