### PR TITLE
Fixes description

### DIFF
--- a/salesforce/10.2/modules/ROOT/pages/salesforce-connector-reference.adoc
+++ b/salesforce/10.2/modules/ROOT/pages/salesforce-connector-reference.adoc
@@ -434,7 +434,7 @@ Aborts an ongoing Bulk API V2 Job.  This call uses the Bulk API v2.
 `<salesforce:abort-query-job-bulk-api-v2>`
 
 
-Retrieves all Bulk Jobs. This call uses the Bulk API v2.
+Abort the indicated query job. This call uses the Bulk API v2.
 
 
 ==== Parameters
@@ -1226,7 +1226,7 @@ Adds one or more new metadata components to your organization.
 `<salesforce:create-query-job-bulk-api-v2>`
 
 
-Retrieves all Bulk Jobs  This call uses the Bulk API v2.
+Creates a query job. This call uses the Bulk API v2.
 
 
 ==== Parameters


### PR DESCRIPTION
the "Get All Jobs Bulk Api V2", "Abort Query Job Bulk Api V2" and "Create Bulk Job Api V2" operations had the exact same description, which doesn't make sense. I have suggested better ones, but it would be ideal to validate this with somebody.