### PR TITLE
Updating Oracle EBS (compatibility with Java 8)

### DIFF
--- a/oracle-ebs/5.1/modules/ROOT/pages/index.adoc
+++ b/oracle-ebs/5.1/modules/ROOT/pages/index.adoc
@@ -14,6 +14,8 @@ Oracle EBS Connector provides integration to the following:
 * XML Gateway: Inbound and Outbound, to send and receive message to and from EBS
 * Business Events: The ability to receive messages when an event is fired in EBS, via the `WF_JMS_JMS_OUT` topic
 
+NOTE: This connector is compatible only with Java 8.
+
 == Prerequisites
 
 To use this information, you should be familiar with Oracle EBS, Mule runtime engine (Mule), Anypoint Connectors, Anypoint Studio, Mule concepts, elements in a Mule flow, and Global Elements.


### PR DESCRIPTION
The connector should be JDK 11 compatible, by End-July