### PR TITLE
Delete buffer unit

### DIFF
--- a/db/1.8/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.8/modules/ROOT/pages/database-documentation.adoc
@@ -1046,11 +1046,6 @@ This operation selects from a table at a regular interval and generates one mess
 |===
 | Field | Type | Description | Default Value | Required
 | In Memory Objects a| Number | The maximum number of instances to keep in memory. If more than the specified maximum is required, then content starts to buffer on disk. |  |
-| Buffer Unit a| Enumeration, one of:
-** BYTE
-** KB
-** MB
-** GB | The unit in which *Max in memory size* is expressed |  |
 |===
 
 [[repeatable-in-memory-stream]]


### PR DESCRIPTION
### Delete buffer unit property from Repeatable File Store Iterable

- Repeatable File Store Iterable can only be configured with the "In Memory Objects" property, and is not compatible with "buffer unit". You can check it in the streaming configuration (https://docs.mulesoft.com/mule-runtime/4.3/streaming-about#repeatable-file-store-iterable). Note that Repeatable File Store Iterable is different from Repeatable File Store Stream.

- Also (https://github.com/mulesoft/mule-ee/blob/9e2751ed3426d1666d2cbcc1886d2fa8daba694c/modules/spring-config/src/main/resources/META-INF/mule-ee.xsd)