### PR TITLE
Added Note to redirect to Azure Service Bus connector for applicable use cases

### DIFF
--- a/microsoft-service-bus/2.2/modules/ROOT/pages/ms-service-bus-connector-reference.adoc
+++ b/microsoft-service-bus/2.2/modules/ROOT/pages/ms-service-bus-connector-reference.adoc
@@ -5,6 +5,8 @@ Support Category: https://www.mulesoft.com/legal/versioning-back-support-policy#
 
 Release Notes: xref:release-notes::connector/ms-service-bus-connector-release-notes-mule-4.adoc[Microsoft Service Bus Connector Release Notes]
 
+**NOTE:** This connector only support connecting to Microsoft Windows Service Bus on-premises solution. To connecto the Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Azure Service Bus connector from MuleSoft]
+
 == Configurations
 ---
 [[config]]

--- a/microsoft-service-bus/2.2/modules/ROOT/pages/ms-service-bus-connector-reference.adoc
+++ b/microsoft-service-bus/2.2/modules/ROOT/pages/ms-service-bus-connector-reference.adoc
@@ -5,7 +5,7 @@ Support Category: https://www.mulesoft.com/legal/versioning-back-support-policy#
 
 Release Notes: xref:release-notes::connector/ms-service-bus-connector-release-notes-mule-4.adoc[Microsoft Service Bus Connector Release Notes]
 
-**NOTE:** This connector only supports connecting to the Microsoft Windows Service Bus on-premises solution. To connect to Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Anypoint Connector for Azure Service Bus].
+**NOTE:** This connector supports connecting to only the Microsoft Windows Service Bus on-premises solution. To connect to Microsoft Azure Service Bus, use https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Anypoint Connector for Azure Service Bus].
 
 == Configurations
 ---

--- a/microsoft-service-bus/2.2/modules/ROOT/pages/ms-service-bus-connector-reference.adoc
+++ b/microsoft-service-bus/2.2/modules/ROOT/pages/ms-service-bus-connector-reference.adoc
@@ -5,7 +5,7 @@ Support Category: https://www.mulesoft.com/legal/versioning-back-support-policy#
 
 Release Notes: xref:release-notes::connector/ms-service-bus-connector-release-notes-mule-4.adoc[Microsoft Service Bus Connector Release Notes]
 
-**NOTE:** This connector only support connecting to Microsoft Windows Service Bus on-premises solution. To connecto the Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Azure Service Bus connector from MuleSoft]
+**NOTE:** This connector only supports connecting to the Microsoft Windows Service Bus on-premises solution. To connect to Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Anypoint Connector for Azure Service Bus].
 
 == Configurations
 ---


### PR DESCRIPTION
Added a Note in the beginning of the connector reference indicating that users who intend to use Azure Service Bus, should use the Azure Service Bus connector