### PR TITLE
Added Note to redirect to Azure Service Bus connector for applicable …

### DIFF
--- a/microsoft-service-bus/2.2/modules/ROOT/pages/index.adoc
+++ b/microsoft-service-bus/2.2/modules/ROOT/pages/index.adoc
@@ -10,6 +10,8 @@ To implement message integration scenarios with Microsoft Azure, use the Microso
 Release Notes: xref:release-notes::connector/ms-service-bus-connector-release-notes-mule-4.adoc[Microsoft Service Bus Connector Release Notes] +
 Exchange: https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-microsoft-service-bus-connector/[Microsoft Service Bus Connector]
 
+**NOTE:** This connector only support connecting to Microsoft Windows Service Bus on-premises solution. To connecto the Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Azure Service Bus connector from MuleSoft]
+
 == Prerequisites
 
 To use this connector, you should be familiar with Microsoft Service Bus, Mule runtime engine (Mule), Anypoint Connectors, Anypoint Studio, Mule concepts, elements in a Mule flow, and Global Elements.

--- a/microsoft-service-bus/2.2/modules/ROOT/pages/index.adoc
+++ b/microsoft-service-bus/2.2/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ To implement message integration scenarios with Microsoft Azure, use the Microso
 Release Notes: xref:release-notes::connector/ms-service-bus-connector-release-notes-mule-4.adoc[Microsoft Service Bus Connector Release Notes] +
 Exchange: https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-microsoft-service-bus-connector/[Microsoft Service Bus Connector]
 
-**NOTE:** This connector only support connecting to Microsoft Windows Service Bus on-premises solution. To connecto the Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Azure Service Bus connector from MuleSoft]
+**NOTE:** This connector only supports connecting to the Microsoft Windows Service Bus on-premises solution. To connect to Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Anypoint Connector for Azure Service Bus].
 
 == Prerequisites
 

--- a/microsoft-service-bus/2.2/modules/ROOT/pages/index.adoc
+++ b/microsoft-service-bus/2.2/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ To implement message integration scenarios with Microsoft Azure, use the Microso
 Release Notes: xref:release-notes::connector/ms-service-bus-connector-release-notes-mule-4.adoc[Microsoft Service Bus Connector Release Notes] +
 Exchange: https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-microsoft-service-bus-connector/[Microsoft Service Bus Connector]
 
-**NOTE:** This connector only supports connecting to the Microsoft Windows Service Bus on-premises solution. To connect to Microsoft Azure Service Bus, use the https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Anypoint Connector for Azure Service Bus].
+**NOTE:** This connector supports connecting to only the Microsoft Windows Service Bus on-premises solution. To connect to Microsoft Azure Service Bus, use https://www.mulesoft.com/exchange/com.mulesoft.connectors/mule-azure-service-bus-connector[Anypoint Connector for Azure Service Bus].
 
 == Prerequisites
 


### PR DESCRIPTION
…use cases

Added a Note in the beginning of the connector reference indicating that users who intend to use Azure Service Bus, should use the Azure Service Bus connector