### PR TITLE
Removed section that references a demo in SharePoint Connector docs

### DIFF
--- a/sharepoint/3.1/modules/ROOT/pages/index.adoc
+++ b/sharepoint/3.1/modules/ROOT/pages/index.adoc
@@ -248,27 +248,6 @@ INFO  2019-10-14 22:12:42,006 [main] org.mule.module.launcher.StartupSummaryDepl
 ************************************************************************
 ----
 
-== Example: SharePoint Connector
-
-This example demonstrates the use of Microsoft SharePoint Connector.
-
-To build and run this demo project, you need:
-
-* Anypoint Studio with at least the Mule 4.0 Runtime.
-* Microsoft SharePoint Connector v2.0.0 or higher.
-
-=== Test the Flow
-
-. Import the demo project to your workspace using Anypoint Exchange or use the *File* > *Import* command.
-. Specify your credentials in the `/src/main/app/mule-app.properties` file:
-. Run the project in Studio.
-. Type `+localhost:8081/demo+` in your browser to access the selection menu of the demo.
-. Optionally you can configure *Connection Timeout* and *Read Timeout*.
-*Connection Timeout* - Makes the initial connection with the server.
-*Read Timeout* - Waits to read data from the server.
-
-You can either use the selection menu from `+http://localhost:8081+` to test the flows or you can POST JSONs using a tool like curl, or any other tool (Chrome/Mozilla Firefox extensions) that lets you post an HTTP body when calling the URL.
-
 == Frequently Asked Questions
 
 * Which versions of SharePoint are supported by this connector?


### PR DESCRIPTION
Customers can't access the Mule 4 demos, so I removed the demo section
