### PR TITLE
DOCS-8855-Email-XML-send-fix-kt

### DIFF
--- a/email/1.2/modules/ROOT/pages/email-send.adoc
+++ b/email/1.2/modules/ROOT/pages/email-send.adoc
@@ -20,7 +20,7 @@ Here is an example of an SMTP configuration:
 [source,xml,linenums]
 ----
 <email:smtp-config name="smtp">
-    <email:stmp-connection host="smtp.gmail.com" port="995" user="pablo.musumeci@mulesoft.com" password="#netherlands!"/>
+    <email:stmp-connection host="smtp.gmail.com" port="995" user="user1@domain.com" password="#passwordvalue!"/>
 </email:smtp-config>
 ----
 
@@ -34,7 +34,7 @@ Here is an SMTPS example:
 [source,xml,linenums]
 ----
 <email:smtp-config name="smtp">
-    <email:stmps-connection host="pop.gmail.com" port="995" user="pablo.musumeci@mulesoft.com" password="#netherlands!"/>
+    <email:stmps-connection host="pop.gmail.com" port="995" user="user2@domain.com" password="#passwordvalue"/>
         <tls:context enabledProtocols="TLSv1.2,SSLv3">
             <tls:key-store path="aKeystore" password="password"/>
             <tls:trust-store path="aTruststore.jks" password="changeit"/>
@@ -49,13 +49,13 @@ This example that sends an email:
 
 [source,xml,linenums]
 ----
-<email:send config-ref="smtp" subject="IMPORTANT!" fromAddress="musumeci@mulesoft.com">
+<email:send config-ref="smtp" subject="IMPORTANT!" fromAddress="user3@domain.com">
     <email:to-addresses>
-        <email:to-address value="ale.gamarra@mulesoft.com"/>
-        <email:to-address value="agustin.celentandios@mulesoft.com"/>
+        <email:to-address value="user1@domain.com"/>
+        <email:to-address value="user2@domain.com"/>
     </email:to-addresses>
     <email:body contentType="text/html">
-        <email:content>"<h1>Hello this is an important message</h1>"</email:content>
+        <email:content><![CDATA["<h1>Hello this is an important message</h1>"]]></email:content>
     </email:body>
 </email:send>
 ----
@@ -79,10 +79,10 @@ In this example, a flow reads a JSON file using the File connector, then uses th
   <file:read path="/file.json"/>
   <email:send config-ref="config">
       <email:to-addresses>
-          <email:to-address value="agusto.celentandios@mulesoft.com"/>
+          <email:to-address value="example@domain.com"/>
       </email:to-addresses>
       <email:body>
-          <email:content>Sending attachments!</email:content>
+          <email:content><![CDATA["<h1>Hello this is an important message</h1>"]]></email:content>
       </email:body>
       <email:attachments>
         #[{
@@ -108,7 +108,7 @@ You can send multiple attachments of different media types, for example, you mig
 
     <email:send config-ref="config">
         <email:to-addresses>
-            <email:to-address value="john.watson@mulesoft.com"/>
+            <email:to-address value="user4@domain.com"/>
         </email:to-addresses>
         <email:body contentType="text/plain">
             <email:content>Email Content</email:content>


### PR DESCRIPTION
Added the CDATA, otherwise the xml parser treats the 'H1' tag as child element