### PR TITLE
Update mongodb-connector-reference.adoc - FindDocuments Default value to retrieve the complete document

### DIFF
--- a/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -693,7 +693,7 @@ Finds all documents that match a given query. If no query is specified, all docu
 * <<repeatable-file-store-iterable>>
 * non-repeatable-iterable |  Configures the streaming strategy for messages |  |
 | Collection Name a| String |  |  | x
-| Fields a| String | Comma-separated list of fields to return from each document. |  | x
+| Fields a| String | Comma-separated list of fields to return from each document. To retrieve full document use comma ",".|  | x
 | Target Variable a| String |  The name of a variable in which to store the operation's output |  |
 | Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  #[payload] |
 | Reconnection Strategy a| * <<reconnect>>

--- a/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -693,7 +693,7 @@ Finds all documents that match a given query. If no query is specified, all docu
 * <<repeatable-file-store-iterable>>
 * non-repeatable-iterable |  Configures the streaming strategy for messages |  |
 | Collection Name a| String |  |  | x
-| Fields a| String | Comma-separated list of fields to return from each document. To retrieve full document use comma ",".|  | x
+| Fields a| String | Comma-separated list of fields to return from each document. To retrieve all fields in a document, use a comma (`,` for this value.|  | x
 | Target Variable a| String |  The name of a variable in which to store the operation's output |  |
 | Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  #[payload] |
 | Reconnection Strategy a| * <<reconnect>>

--- a/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -693,7 +693,7 @@ Finds all documents that match a given query. If no query is specified, all docu
 * <<repeatable-file-store-iterable>>
 * non-repeatable-iterable |  Configures the streaming strategy for messages |  |
 | Collection Name a| String |  |  | x
-| Fields a| String | Comma-separated list of fields to return from each document. To retrieve all fields in a document, use a comma (`,` for this value.|  | x
+| Fields a| String | Comma-separated list of fields to return from each document. To retrieve all fields in a document, set this value to `,`.|  | x
 | Target Variable a| String |  The name of a variable in which to store the operation's output |  |
 | Target Value a| String |  An expression to evaluate against the operation's output and store the expression outcome in the target variable |  #[payload] |
 | Reconnection Strategy a| * <<reconnect>>


### PR DESCRIPTION
In Documentation, it wasn't mentioned what is the default value to retrieve the complete document.
Fields a| String | Comma-separated list of fields to return from each document. To retrieve full document use comma ",".|