### PR TITLE
DOCS-5518-sockets-protocols-reference-kt

### DIFF
--- a/sockets/1.2/modules/ROOT/pages/sockets-documentation.adoc
+++ b/sockets/1.2/modules/ROOT/pages/sockets-documentation.adoc
@@ -512,6 +512,8 @@ Listens for socket connections of the given protocol in the configured host and 
 [[SafeProtocol]]
 === Safe Protocol
 
+This test protocol precedes every message with a cookie, and should not be used in production environments.
+
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
@@ -523,6 +525,8 @@ Listens for socket connections of the given protocol in the configured host and 
 [[DirectProtocol]]
 === Direct Protocol
 
+This protocol allows the socket to read until no more bytes are immediately available. On slow networks, EOFProtocol and LengthProtocol might be more reliable.
+
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
@@ -531,6 +535,8 @@ Listens for socket connections of the given protocol in the configured host and 
 
 [[LengthProtocol]]
 === Length Protocol
+
+This protocol is defined by sending or reading an integer (the packet length) and then the data to transfer.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
@@ -542,6 +548,8 @@ Listens for socket connections of the given protocol in the configured host and 
 [[StreamingProtocol]]
 === Streaming Protocol
 
+This protocol allows the socket’s Send operation to return a message with the original InputStream as payload.
+
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
@@ -549,7 +557,11 @@ Listens for socket connections of the given protocol in the configured host and 
 |===
 
 [[XmlMessageProtocol]]
-=== Xml Message Protocol
+=== XML Message Protocol
+
+This protocol reads streaming XML documents. The only requirement is that each document includes an XML declaration at the beginning of the document in the form of <?xml…​..
+Data is read until a new document is found or until there is no more currently available data. For slower networks, XmlMessageEofProtocol might be more reliable.
+Also, because the default character encoding for the platform is used to decode the message bytes when looking for the XML declaration, some caution with message character encodings is warranted.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
@@ -558,7 +570,9 @@ Listens for socket connections of the given protocol in the configured host and 
 |===
 
 [[xml-message-eof-protocol]]
-=== Xml Message Eof Protocol
+=== XML Message Eof Protocol
+
+This protocol extends XmlMessageProtocol to continue reading until either a new message or EOF is found.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
@@ -568,6 +582,8 @@ Listens for socket connections of the given protocol in the configured host and 
 
 [[CustomProtocol]]
 === Custom Protocol
+
+Define your own custom protocol by writing a class that extends TcpProtocol.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===

--- a/sockets/1.2/modules/ROOT/pages/sockets-documentation.adoc
+++ b/sockets/1.2/modules/ROOT/pages/sockets-documentation.adoc
@@ -525,7 +525,7 @@ This test protocol precedes every message with a cookie, and should not be used 
 [[DirectProtocol]]
 === Direct Protocol
 
-This protocol allows the socket to read until no more bytes are immediately available. On slow networks, EOFProtocol and LengthProtocol might be more reliable.
+This protocol allows the socket to read until no more bytes are immediately available. On slow networks, `EOFProtocol` and `LengthProtocol` might be more reliable.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
@@ -559,9 +559,9 @@ This protocol allows the socket’s Send operation to return a message with the 
 [[XmlMessageProtocol]]
 === XML Message Protocol
 
-This protocol reads streaming XML documents. The only requirement is that each document includes an XML declaration at the beginning of the document in the form of <?xml…​..
-Data is read until a new document is found or until there is no more currently available data. For slower networks, XmlMessageEofProtocol might be more reliable.
-Also, because the default character encoding for the platform is used to decode the message bytes when looking for the XML declaration, some caution with message character encodings is warranted.
+This protocol reads streaming XML documents. The only requirement is that each document includes an XML declaration at the beginning of the document in the form of `<?xml…​.`.
+Data is read until a new document is found or until there is no more currently available data. For slower networks, `XmlMessageEofProtocol` might be more reliable.
+Also, because the default character encoding for Anypoint Platform is used to decode the message bytes when looking for the XML declaration, some caution with message character encodings is warranted.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
@@ -572,7 +572,7 @@ Also, because the default character encoding for the platform is used to decode 
 [[xml-message-eof-protocol]]
 === XML Message Eof Protocol
 
-This protocol extends XmlMessageProtocol to continue reading until either a new message or EOF is found.
+This protocol extends `XmlMessageProtocol` to continue reading until either a new message or EOF is found.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
@@ -583,7 +583,7 @@ This protocol extends XmlMessageProtocol to continue reading until either a new 
 [[CustomProtocol]]
 === Custom Protocol
 
-Define your own custom protocol by writing a class that extends TcpProtocol.
+Define your own custom protocol by writing a class that extends `TcpProtocol`.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
@@ -594,6 +594,8 @@ Define your own custom protocol by writing a class that extends TcpProtocol.
 [[eof-protocol]]
 === Eof Protocol
 
+Reading is terminated by the stream being closed by the client.
+
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
@@ -602,6 +604,8 @@ Define your own custom protocol by writing a class that extends TcpProtocol.
 
 [[CustomClassLoadingLengthProtocol]]
 === Custom Class Loading Length Protocol
+
+A length protocol that uses a specific class loader to load objects from streams.
 
 [%header,cols="20s,25a,30a,15a,10a"]
 |===


### PR DESCRIPTION
Per external feedback received adding Sockets Supported Protocols in the Sockets Reference documentation.