### PR TITLE
Remove duplicated page-alias

### DIFF
--- a/salesforce/10.0/modules/ROOT/pages/salesforce-connector-upgrade-migrate.adoc
+++ b/salesforce/10.0/modules/ROOT/pages/salesforce-connector-upgrade-migrate.adoc
@@ -1,5 +1,4 @@
 = Salesforce - Upgrade and Migrate - Mule 4
-:page-aliases: connectors::salesforce/salesforce-connector-100-upgrade-migrate.adoc
 
 Upgrade Anypoint Connector for Salesforce (Salesforce Connector) to version 10.x.
 


### PR DESCRIPTION
This PR removes the duplicated page-alias from salesforce/10.0/modules/ROOT/pages/salesforce-connector-upgrade-migrate.adoc

The :page-aliases: macro for this topic should be salesforce/10.4/modules/ROOT/pages/salesforce-connector-upgrade-migrate.adoc