### PR TITLE
DOCS-2583

### DIFF
--- a/amqp/0.3.8/modules/ROOT/pages/index.adoc
+++ b/amqp/0.3.8/modules/ROOT/pages/index.adoc
@@ -176,55 +176,6 @@ To add the Mule AMQP connector to a Maven project, add the following dependency 
 </inclusions>
 ----
 
-////
-DOCS-1555
-////
-
-[NOTE]
-====
-You also need to add JARs included in the ActiveMQ distribution. The following dependencies provide a Maven alternative to only adding JARs to an Anypoint Studio project.
-
-Studio does not add these dependencies for you, so it's important to add these dependencies.
-
-After adding the dependencies to the POM file, add the files from the Active MQ distribution to $MULE_HOME/lib/user or $APP_HOME/lib. The latter can be done manually or by using Studio.
-====
-
-Dependencies:
-
-[source,xml,linenums]
-----
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-kahadb-store</artifactId>
-    <version>5.8.0</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq.protobuf</groupId>
-    <artifactId>activemq-protobuf</artifactId>
-    <version>1.1</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-openwire-legacy</artifactId>
-    <version>5.8.0</version>
-</dependency>
-<dependency>
-  <groupId>org.fusesource.hawtbuf</groupId>
-  <artifactId>hawtbuf</artifactId>
-  <version>1.9</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-broker</artifactId>
-    <version>5.8.0</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-client</artifactId>
-    <version>5.8.0</version>
-</dependency>
-----
-
 == Studio Plugin
 
 The AMQP connector is available as a https://www.mulesoft.com/exchange/org.mule.modules/mule-transport-amqp-studio/[Studio plugin] in Anypoint Exchange.

--- a/amqp/0.3.9/modules/ROOT/pages/index.adoc
+++ b/amqp/0.3.9/modules/ROOT/pages/index.adoc
@@ -162,50 +162,6 @@ To add the Mule AMQP connector to a Maven project, add the following dependency 
 </inclusions>
 ----
 
-[NOTE]
-====
-You also need to add JARs included in the ActiveMQ distribution. The following dependencies provide a Maven alternative to only adding JARs to an Anypoint Studio project.
-
-Studio does not add these dependencies for you, so it's important to add these dependencies.
-
-After adding the dependencies to the POM file, add the files from the Active MQ distribution to $MULE_HOME/lib/user or $APP_HOME/lib. The latter can be done manually or by using Studio.
-====
-
-Dependencies:
-
-[source,xml,linenums]
-----
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-kahadb-store</artifactId>
-    <version>5.8.0</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq.protobuf</groupId>
-    <artifactId>activemq-protobuf</artifactId>
-    <version>1.1</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-openwire-legacy</artifactId>
-    <version>5.8.0</version>
-</dependency>
-<dependency>
-  <groupId>org.fusesource.hawtbuf</groupId>
-  <artifactId>hawtbuf</artifactId>
-  <version>1.9</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-broker</artifactId>
-    <version>5.8.0</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.activemq</groupId>
-    <artifactId>activemq-client</artifactId>
-    <version>5.8.0</version>
-</dependency>
-----
 
 == Configuring the AMQP Connector
 


### PR DESCRIPTION
Removed ActiveMQ info that was erroneously added per Docs-1555
The information was originally supposed to be added to JMS Connector, not AMQP