### PR TITLE
Remove primary node in a distributed environment context

### DIFF
--- a/salesforce/10.3/modules/ROOT/pages/salesforce-connector-config-topics.adoc
+++ b/salesforce/10.3/modules/ROOT/pages/salesforce-connector-config-topics.adoc
@@ -14,7 +14,7 @@ You can use Salesforce Connector as an inbound connector to stream data from Sal
 
 For the Replay Topic Listener and Replay Channel Listener, in order to enable the *Resume from the Last Replay Id* functionality, the connector must store some information regarding the events that were successfully processed by the flow in which the listener is used. In order to do so, the connector is using the Object Store. For more details of how the Object Store is used check the <<objectstoreusage, Object Store Usage>> section.
 
-Please keep in mind that when deploying on a distributed environment(such as CloudHub), the source needs to run on the primary node. If the same source runs on multiple nodes, then you will experience duplicate event consumption.
+Please keep in mind that when deploying on a distributed environment (such as CloudHub), if the same source runs on multiple nodes, then you will experience duplicate event consumption.
 
 [[createtopic]]
 === Create a Topic to Receive Data from Salesforce

--- a/salesforce/10.3/modules/ROOT/pages/salesforce-connector-config-topics.adoc
+++ b/salesforce/10.3/modules/ROOT/pages/salesforce-connector-config-topics.adoc
@@ -14,7 +14,8 @@ You can use Salesforce Connector as an inbound connector to stream data from Sal
 
 For the Replay Topic Listener and Replay Channel Listener, in order to enable the *Resume from the Last Replay Id* functionality, the connector must store some information regarding the events that were successfully processed by the flow in which the listener is used. In order to do so, the connector is using the Object Store. For more details of how the Object Store is used check the <<objectstoreusage, Object Store Usage>> section.
 
-Please keep in mind that when deploying on a distributed environment (such as CloudHub), if the same source runs on multiple nodes, then you will experience duplicate event consumption.
+[NOTE]
+When deploying on a distributed environment (such as CloudHub), if the same source runs on multiple nodes, duplicate event consumption occurs. 
 
 [[createtopic]]
 === Create a Topic to Receive Data from Salesforce


### PR DESCRIPTION
Primary node makes sense only in a cluster environment, not in CloudHub. There are no primary nodes in CloudHub. Please add details of how this works in a cluster if that makes sense.