### PR TITLE
Docs-9089 Fix Azure Service Bus Connector link to release notes

### DIFF
--- a/microsoft-azure-sb/0.3.9/antora.yml
+++ b/microsoft-azure-sb/0.3.9/antora.yml
@@ -12,6 +12,6 @@ asciidoc:
     page-exchange-group-id: com.mulesoft.connectors
     page-exchange-asset-id: mule-module-microsoft-azure-servicebus
     page-runtime-version: 3.7.0
-    page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes-mule-4.adoc
+    page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes.adoc
     page-vendor-name: microsoft
     page-vendor-title: Microsoft

--- a/microsoft-azure-sb/0.3.9/antora.yml
+++ b/microsoft-azure-sb/0.3.9/antora.yml
@@ -12,6 +12,6 @@ asciidoc:
     page-exchange-group-id: com.mulesoft.connectors
     page-exchange-asset-id: mule-module-microsoft-azure-servicebus
     page-runtime-version: 3.7.0
-    page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes.adoc
+    page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes-mule-4.adoc
     page-vendor-name: microsoft
     page-vendor-title: Microsoft

--- a/microsoft-azure-sb/3.0/antora.yml
+++ b/microsoft-azure-sb/3.0/antora.yml
@@ -10,8 +10,8 @@ asciidoc:
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: com.mulesoft.connectors
-    page-exchange-asset-id: mule-azure-service-bus-connector
+    page-exchange-asset-id: mule-azure-service-bus-Connector
     page-runtime-version: 4.2.1
-    page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes.adoc
+    page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes-mule-4.adoc
     page-vendor-name: microsoft
     page-vendor-title: Microsoft

--- a/microsoft-azure-sb/3.0/antora.yml
+++ b/microsoft-azure-sb/3.0/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: com.mulesoft.connectors
-    page-exchange-asset-id: mule-azure-service-bus-Connector
+    page-exchange-asset-id: mule-azure-service-bus-connector
     page-runtime-version: 4.2.1
     page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes-mule-4.adoc
     page-vendor-name: microsoft

--- a/microsoft-azure-sb/3.0/antora.yml
+++ b/microsoft-azure-sb/3.0/antora.yml
@@ -12,6 +12,6 @@ asciidoc:
     page-exchange-group-id: com.mulesoft.connectors
     page-exchange-asset-id: mule-azure-service-bus-connector
     page-runtime-version: 4.2.1
-    page-release-notes-page: release-notes::connector/microsoft-azure-service-bus-connector-release-notes-mule-4.adoc
+    page-release-notes-page: release-notes::connector/azure-service-bus-connector-release-notes-mule-4.adoc
     page-vendor-name: microsoft
     page-vendor-title: Microsoft


### PR DESCRIPTION
In the connectors landing page, the Azure Service Bus Connector link to the Mule release notes goes to the Mule3 release notes instead of Mule 4.