### PR TITLE
Update salesforce-connector-reference.adoc

### DIFF
--- a/salesforce/10.5/modules/ROOT/pages/salesforce-connector-reference.adoc
+++ b/salesforce/10.5/modules/ROOT/pages/salesforce-connector-reference.adoc
@@ -2521,7 +2521,9 @@ Invokes any operation from an Apex class that is exposed as a REST web service.
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
-| Request a| Object |  Object containing request information |  `#[payload]` |
+| Request a| Object |  Object containing request information.
+
+Some of this information can include object queryParams with key and value pairs. These parameters will be passed as URL parameters to the Apex Rest endpoint. For example: queryParams: {AccountId : "a0w0E0000069MDxQAM" , ContactId: "0030E00000rRSJ6QAO" } |  `#[payload]` |
 | Apex Class Name a| String |  |  | x
 | Apex Class Method Name a| String |  |  | x
 | Read Timeout a| Number |  Specifies the amount of time, in the unit defined in Time unit, for which the consumer waits for a response before it times out. |  |


### PR DESCRIPTION
Parameter queryParams is not documented for Apex Rest calls using the Salesforce Connector. This is critical information to be able to call SF Apex Rest endpoints that expects URL parameters.