### PR TITLE
DOCS-9442-http-send-correlationid-kt

### DIFF
--- a/http/1.5/modules/ROOT/pages/http-documentation.adoc
+++ b/http/1.5/modules/ROOT/pages/http-documentation.adoc
@@ -95,7 +95,7 @@ Configuration element for a HTTP requests.
 
 ** AUTO
 ** ALWAYS
-** NEVER |  Whether to specify a Correlation Id when publishing messages. This applies both for custom Correlation Ids specified at the operation level and for default Correlation Ids taken from the current event. |  AUTO |
+** NEVER |  Whether to specify a correlation id when publishing messages. This applies both for custom correlation ids specified at the operation level and for default correlation ids taken from the current event. |  AUTO |
 | Preserve Headers Case a| Boolean |  By default, header keys are stored internally in lower-case. This is to improve performance of headers handling and is functionally correct as specified in the RFC. <p> In the case a server expects headers in a specific case, this flag may be set to true so the case of the header keys are preserved. |  false |
 | Response Timeout a| Number |  Maximum time in milliseconds that the request element blocks the execution of the flow waiting for the HTTP response. If this value is not present, the connector uses the default response timeout from the Mule configuration, which is also 10000 | 10000 |
 | Response Validator a| One of:

--- a/http/1.5/modules/ROOT/pages/http-documentation.adoc
+++ b/http/1.5/modules/ROOT/pages/http-documentation.adoc
@@ -95,7 +95,10 @@ Configuration element for a HTTP requests.
 
 ** AUTO
 ** ALWAYS
-** NEVER |  Whether to specify a correlationId when publishing messages. This applies both for custom correlation ids specifies at the operation level and for default correlation Ids taken from the current event |  AUTO |
+** NEVER |  Whether to specify a Correlation Id when publishing messages. This applies both for custom Correlation Ids specified at the operation level and for default Correlation Ids taken from the current event. Given the strategy selected the connector asks the Correlation Info to give a Correlation Id:
+
+* ALWAYS means that a Correlation Id will always be given.
+* AUTO means that a Correlation Id will be given when Outbound Correlation Ids are enabled at the application level. |  AUTO |
 | Preserve Headers Case a| Boolean |  By default, header keys are stored internally in lower-case. This is to improve performance of headers handling and is functionally correct as specified in the RFC. <p> In the case a server expects headers in a specific case, this flag may be set to true so the case of the header keys are preserved. |  false |
 | Response Timeout a| Number |  Maximum time in milliseconds that the request element blocks the execution of the flow waiting for the HTTP response. If this value is not present, the connector uses the default response timeout from the Mule configuration, which is also 10000 | 10000 |
 | Response Validator a| One of:

--- a/http/1.5/modules/ROOT/pages/http-documentation.adoc
+++ b/http/1.5/modules/ROOT/pages/http-documentation.adoc
@@ -95,10 +95,7 @@ Configuration element for a HTTP requests.
 
 ** AUTO
 ** ALWAYS
-** NEVER |  Whether to specify a Correlation Id when publishing messages. This applies both for custom Correlation Ids specified at the operation level and for default Correlation Ids taken from the current event. Given the strategy selected the connector asks the Correlation Info to give a Correlation Id:
-
-* ALWAYS means that a Correlation Id will always be given.
-* AUTO means that a Correlation Id will be given when Outbound Correlation Ids are enabled at the application level. |  AUTO |
+** NEVER |  Whether to specify a Correlation Id when publishing messages. This applies both for custom Correlation Ids specified at the operation level and for default Correlation Ids taken from the current event. |  AUTO |
 | Preserve Headers Case a| Boolean |  By default, header keys are stored internally in lower-case. This is to improve performance of headers handling and is functionally correct as specified in the RFC. <p> In the case a server expects headers in a specific case, this flag may be set to true so the case of the header keys are preserved. |  false |
 | Response Timeout a| Number |  Maximum time in milliseconds that the request element blocks the execution of the flow waiting for the HTTP response. If this value is not present, the connector uses the default response timeout from the Mule configuration, which is also 10000 | 10000 |
 | Response Validator a| One of:


### PR DESCRIPTION
Per internal feedback received updating HTTP Request Send Correlation ID parameter definitions.
