### PR TITLE
DOCS-9947-http-work-threading-profile-kt

### DIFF
--- a/http/0.3.9/modules/ROOT/pages/http-listener-connector.adoc
+++ b/http/0.3.9/modules/ROOT/pages/http-listener-connector.adoc
@@ -1366,7 +1366,7 @@ Although this default configuration is usually enough, it is possible to tune th
 
 === Worker Threading Profile
 
-Attributes of Worker Threading Profile (`worker-threading-profile`) parameter:
+Attributes of the Worker Threading Profile (`worker-threading-profile`) parameter:
 
 [%header,cols="auto"]
 |===
@@ -1380,25 +1380,25 @@ Attributes of Worker Threading Profile (`worker-threading-profile`) parameter:
 |Pool Exhausted Action | WAIT, DISCARD, DISCARD_OLDEST, ABORT, RUN | When the maximum pool size or queue size is bounded, this value determines how to manage incoming tasks. Possible values are:
 
 * `WAIT` +
-Wait until a thread becomes available; don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
+Wait until a thread becomes available. Don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
 
 * `DISCARD` +
-Throw away the current request and return.
+Throw away the current request and return
 
 * `DISCARD_OLDEST` +
-Throw away the oldest request and return.
+Throw away the oldest request and return
 
 * `ABORT` +
- Throw a RuntimeException.
+ Throw a RuntimeException
 
 * `RUN` +
 The thread making the execute request runs the task itself, which helps guard against lockup. | No | `RUN`
 
-|Thread Wait Timeout | Long |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it waits indefinitely. | No | 30000
+|Thread Wait Timeout | Long |How long the thread waits in milliseconds when the pool exhausted action is `WAIT`. If the value is negative, it waits indefinitely. | No | 30000
 
-|Max Buffer Size | Integer |Determines how many requests to queue when the pool is at maximum usage capacity and the pool exhausted action is WAIT. The buffer throttles for thread creation, before requests are processed.  <<mbsinfo,Do not use maxBufferSize without reading these warnings>>.
+|Max Buffer Size | Integer |Determines how many requests to queue when the pool is at maximum usage capacity and the pool exhausted action is WAIT. The buffer throttles for thread creation before requests are processed.  <<mbsinfo,Do not use maxBufferSize without reading these warnings>>.
 
-Any BlockingQueue can be used to transfer and hold submitted tasks. The use of this queue interacts with pool sizing:
+Any `BlockingQueue` can be used to transfer and hold submitted tasks. The use of this queue interacts with pool sizing:
 
 * If fewer than `corePoolSize` threads are running, the executor always adds a new thread rather than queuing. +
 *Note*: `corePoolSize` is an attribute of the underlying implementation.

--- a/http/0.3.9/modules/ROOT/pages/http-listener-connector.adoc
+++ b/http/0.3.9/modules/ROOT/pages/http-listener-connector.adoc
@@ -1364,6 +1364,50 @@ image::http-listener-connector-51981.png[]
 
 Although this default configuration is usually enough, it is possible to tune the max thread value ^2^
 
+=== Worker Threading Profile
+
+Attributes of Worker Threading Profile (`worker-threading-profile`) parameter:
+
+[%header,cols="auto"]
+|===
+|Name |Type |Description |Required |Default
+|Max Active Thread | Integer |The maximum number of threads to use. | No |16
+
+|Max Idle Threads | Integer |The maximum number of idle or inactive threads that can be in the pool before they are destroyed. | No | 1
+
+|Thread TTL | Integer |Determines how long an inactive thread is kept in the pool before being discarded. | No | 60000
+
+|Pool Exhausted Action | WAIT, DISCARD, DISCARD_OLDEST, ABORT, RUN | When the maximum pool size or queue size is bounded, this value determines how to manage incoming tasks. Possible values are:
+
+* `WAIT` +
+Wait until a thread becomes available; don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
+
+* `DISCARD` +
+Throw away the current request and return.
+
+* `DISCARD_OLDEST` +
+Throw away the oldest request and return.
+
+* `ABORT` +
+ Throw a RuntimeException.
+
+* `RUN` +
+The thread making the execute request runs the task itself, which helps guard against lockup. | No | `RUN`
+
+|Thread Wait Timeout | Integer |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it waits indefinitely. | No | 30000
+
+|Max Buffer Size | Integer |Determines how many requests to queue when the pool is at maximum usage capacity and the pool exhausted action is WAIT. The buffer throttles for thread creation, before requests are processed.  <<mbsinfo,Do not use maxBufferSize without reading these warnings>>.
+
+Any BlockingQueue can be used to transfer and hold submitted tasks. The use of this queue interacts with pool sizing:
+
+* If fewer than `corePoolSize` threads are running, the executor always adds a new thread rather than queuing. +
+*Note*: `corePoolSize` is an attribute of the underlying implementation.
+
+* If `corePoolSize` or more threads are running, the executor always queues a request rather than adding a new thread.
+
+* If a request cannot be queued, a new thread is created unless this exceeds `maximumPoolSize`, in which case, the task is rejected. | No | 0
+|===
+
 
 [.ex]
 =====

--- a/http/0.3.9/modules/ROOT/pages/http-listener-connector.adoc
+++ b/http/0.3.9/modules/ROOT/pages/http-listener-connector.adoc
@@ -1375,7 +1375,7 @@ Attributes of Worker Threading Profile (`worker-threading-profile`) parameter:
 
 |Max Idle Threads | Integer |The maximum number of idle or inactive threads that can be in the pool before they are destroyed. | No | 1
 
-|Thread TTL | Integer |Determines how long an inactive thread is kept in the pool before being discarded. | No | 60000
+|Thread TTL | Long |Determines how long an inactive thread is kept in the pool before being discarded. | No | 60000
 
 |Pool Exhausted Action | WAIT, DISCARD, DISCARD_OLDEST, ABORT, RUN | When the maximum pool size or queue size is bounded, this value determines how to manage incoming tasks. Possible values are:
 
@@ -1394,7 +1394,7 @@ Throw away the oldest request and return.
 * `RUN` +
 The thread making the execute request runs the task itself, which helps guard against lockup. | No | `RUN`
 
-|Thread Wait Timeout | Integer |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it waits indefinitely. | No | 30000
+|Thread Wait Timeout | Long |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it waits indefinitely. | No | 30000
 
 |Max Buffer Size | Integer |Determines how many requests to queue when the pool is at maximum usage capacity and the pool exhausted action is WAIT. The buffer throttles for thread creation, before requests are processed.  <<mbsinfo,Do not use maxBufferSize without reading these warnings>>.
 


### PR DESCRIPTION
Adding worker-threading-profile configurable attributes for HTTP Listener (Mule 3)