### PR TITLE
Update kafka-connector-studio.adoc

### DIFF
--- a/kafka/4.4/modules/ROOT/pages/kafka-connector-studio.adoc
+++ b/kafka/4.4/modules/ROOT/pages/kafka-connector-studio.adoc
@@ -215,6 +215,7 @@ image::kafka-publish-studio-config.png[]
 | Configuration | String | The name of the configuration to use. | | x
 | Topic a| String |  The name of the topic on which to perform the seek operation. |  | x
 | Partition a| Number |  The partition number that will have its offset modified. |  | x
+| Offset a| ? |  ? |  | x
 |===
 +
 . Configure the following settings in the *Advanced* tab:


### PR DESCRIPTION
The documentation forgets about the offset for the Seek operation and what is this Input Source section about? The Seek operation also doesn't have a screenshot of the connector config screen.