### PR TITLE
Change verbiage for vm:consume operation

### DIFF
--- a/vm/2.0/modules/ROOT/pages/vm-reference.adoc
+++ b/vm/2.0/modules/ROOT/pages/vm-reference.adoc
@@ -65,7 +65,7 @@ Returns instances of VMConnection.
 
 This operation pulls a message from a queue. If a message is not immediately available, the Consume operation waits for up to the configured `queueTimeout` value, after which a `VM:QUEUE_TIMEOUT` error is thrown.
 
-The flow in which the content is published cannot contain a Listener (`<vm:listener>`) source.
+The flow in which the content is consumed cannot contain a Listener (`<vm:listener>`) source.
 
 ==== Parameters
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]


### PR DESCRIPTION
Current verbiage for vm:consume reads 'The flow in which the content is published cannot contain a Listener (<vm:listener>) source'. Here 'content is published' is slightly misleading as the topic is about consuming the message.