### PR TITLE
DOCS-10494-db-JDBC-data-type-kt

### DIFF
--- a/db/1.9/modules/ROOT/pages/database-configure-data-types.adoc
+++ b/db/1.9/modules/ROOT/pages/database-configure-data-types.adoc
@@ -40,7 +40,57 @@ In the XML editor, the `<db:parameter-types>` configuration looks like this:
 
 == Configure the Column Types Field in Studio
 
-Each connection provider uses exclusive and common parameters, such as Derby and Oracle. A child element of the connection provider element defines custom data types parameters you can use when connected to a particular provider. The following example shows how to configure the Column Types field in the Derby global configuration connection element:
+Each connection provider uses exclusive and common parameters, such as Derby and Oracle. A child element of the connection provider element defines custom data types parameters you can use when connected to a particular provider.
+
+The following table provides the JDBC Data Type codes and ids that you can use to define custom data types:
+
+[%header%autowidth,width=80%]
+|===
+|JDBC Data Type Code |id
+|ARRAY	|2003
+|BIGINT	|-5
+|BINARY	|-2
+|BIT	|-7
+|BLOB	|2004
+|BOOLEAN	|16
+|CHAR	|1
+|CLOB	|2005
+|DATALINK	|70
+|DATE	|91
+|DECIMAL	|3
+|DISTINCT	|2001
+|DOUBLE	|8
+|FLOAT	|6
+|INTEGER	|4
+|JAVA_OBJECT	|2000
+|LONGNVARCHAR	|-16
+|LONGVARBINARY	|-4
+|LONGVARCHAR	|-1
+|NCHAR	|-15
+|NCLOB	|2011
+|NULL	|0
+|NUMERIC	|2
+|NVARCHAR	|-9
+|OTHER	|1111
+|REAL	|7
+|REF	|2006
+|REF_CURSOR	|2012
+|ROWID	|-8
+|SMALLINT	|5
+|SQLXML	|2009
+|STRUCT	|2002
+|TIME	|92
+|TIME_WITH_TIMEZONE	|2013
+|TIMESTAMP	|93
+|TIMESTAMP_WITH_TIMEZONE	|2014
+|TINYINT	|-6
+|VARBINARY	|-3
+|VARCHAR	|12
+|===
+
+
+
+The following example shows how to configure the Column Types field in the Derby global configuration connection element:
 
 
 . In Studio, navigate to the *Global Elements* tab.

--- a/db/1.9/modules/ROOT/pages/database-configure-data-types.adoc
+++ b/db/1.9/modules/ROOT/pages/database-configure-data-types.adoc
@@ -42,7 +42,7 @@ In the XML editor, the `<db:parameter-types>` configuration looks like this:
 
 Each connection provider uses exclusive and common parameters, such as Derby and Oracle. A child element of the connection provider element defines custom data types parameters you can use when connected to a particular provider.
 
-The following table provides the JDBC Data Type codes and ids that you can use to define custom data types:
+The following table provides the JDBC Data Type codes and IDs that you can use to define custom data types:
 
 [%header%autowidth,width=80%]
 |===


### PR DESCRIPTION
Adding JDBC Data Types code list with IDs that can be used to configure in the Column Types field