### PR TITLE
DOCS-10735-http-requester-reconnection-kt

### DIFF
--- a/http/1.5/modules/ROOT/pages/http-documentation.adoc
+++ b/http/1.5/modules/ROOT/pages/http-documentation.adoc
@@ -197,7 +197,7 @@ Consumes an HTTP service.
 | Target Variable a| String |  The name of a variable on which the operation's output will be placed |  |
 | Target Value a| String |  An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable |  #[payload] |
 | Reconnection Strategy a| * <<reconnect>>
-* <<reconnect-forever>> |  A retry strategy in case of connectivity errors |  |
+* <<reconnect-forever>> |  A retry strategy in case of connectivity errors. This field is not used by this operation. |  |
 |===
 
 ==== Output

--- a/http/1.5/modules/ROOT/pages/http-request-ref.adoc
+++ b/http/1.5/modules/ROOT/pages/http-request-ref.adoc
@@ -196,7 +196,7 @@ To avoid issues, it's important to consume responses when streaming.
 The HTTP Connector uses a retry mechanism that enables you to configure how many times it tries consuming an external HTTP service. The HTTP Connector uses this mechanism to reconnect an HTTP client with an HTTP service. The HTTP Connector does not manage TCP connections, so this mechanism does not reconnect sockets.
 
 [WARNING]
-The *HTTP Requester operation* does not use the reconnection strategy for retries. The reconnection strategy is a mechanism the Mule SDK uses to re-establish _Connections_ when a `ConnectionException` is caught. It does not affect connections to an HTTP service created by the HTTP Requester.
+The *HTTP Request* operation does not use the reconnection strategy for retries. The reconnection strategy is a mechanism the Mule SDK uses to re-establish _Connections_ when a `ConnectionException` is caught. It does not affect connections to an HTTP service created by the HTTP Requester.
 To learn more about _Connections_, see xref:mule-sdk::connections.adoc[Connections documentation]
 
 To configure how many times the HTTP Requester can try consuming an external HTTP service (_retries_), you can either use the Until Successful scope, or the built-in retry mechanism in the requester:

--- a/http/1.5/modules/ROOT/pages/http-request-ref.adoc
+++ b/http/1.5/modules/ROOT/pages/http-request-ref.adoc
@@ -196,7 +196,7 @@ To avoid issues, it's important to consume responses when streaming.
 The HTTP Connector uses a retry mechanism that enables you to configure how many times it tries consuming an external HTTP service. The HTTP Connector uses this mechanism to reconnect an HTTP client with an HTTP service. The HTTP Connector does not manage TCP connections, so this mechanism does not reconnect sockets.
 
 [WARNING]
-The reconnection strategy is a mechanism the Mule SDK uses to re-establish _Connections_ when a `ConnectionException` is caught. It does not affect connections to an HTTP service created by the HTTP Requester.
+The *HTTP Requester operation* does not use the reconnection strategy for retries. The reconnection strategy is a mechanism the Mule SDK uses to re-establish _Connections_ when a `ConnectionException` is caught. It does not affect connections to an HTTP service created by the HTTP Requester.
 To learn more about _Connections_, see xref:mule-sdk::connections.adoc[Connections documentation]
 
 To configure how many times the HTTP Requester can try consuming an external HTTP service (_retries_), you can either use the Until Successful scope, or the built-in retry mechanism in the requester:


### PR DESCRIPTION
Updated warning message and Connector reference that  HTTP Request operation does not use reconnection strategy for retries.