### PR TITLE
DOCS-7372-ftp-read-clarification-kt

### DIFF
--- a/ftp/1.5/modules/ROOT/pages/ftp-read.adoc
+++ b/ftp/1.5/modules/ROOT/pages/ftp-read.adoc
@@ -3,6 +3,8 @@
 
 In Mule 4, the FTP connector can read a file at any point in the flow, unlike in Mule 3 where transport could only read files as a result of inbound endpoint polling.
 
+When the file is read from the FTP source folder, the default behavior of the operation in Mule 4 is that it remains in the same folder until it is manually deleted.
+
 Here is the syntax for reading a file:
 
 [source,xml,linenums]


### PR DESCRIPTION
Added clarification for FTP Read operation when when reading the file from the FTP source folder.