### PR TITLE
DOCS-10855-jms-reference-kt

### DIFF
--- a/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
@@ -501,7 +501,7 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 |===
 | Field | Type | Description | Default Value | Required
 | All a| Any | All the properties of the JMS message as a flattened map. |  | x
-| User Properties a| Any | The user provided properties of the JMS message.  |  | x
+| User Properties a| Any | The user-provided properties of the JMS message.  |  | x
 | Jms Properties a| Any | JMS message broker and provider properties. |  | x
 | Jmsx Properties a| <<JMSXProperties>> | JMSX properties of the JMS message  |  |
 |===

--- a/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
@@ -489,9 +489,9 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Properties a| <<JMSMessageProperties>> |  |  |
-| Headers a| Any |  |  | x
-| Ack Id a| String |  |  |
+| Properties a| <<JMSMessageProperties>> | Container element for all the properties present in a JMS Message. |  |
+| Headers a| Any | All the possible headers of a JMS message. |  | x
+| Ack Id a| String | The session Ack ID required to acknowledge at the current message if one is available, otherwise, is null.  |  |
 |===
 
 [[JMSMessageProperties]]
@@ -500,10 +500,10 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| All a| Any |  |  | x
-| User Properties a| Any |  |  | x
-| Jms Properties a| Any |  |  | x
-| Jmsx Properties a| <<JMSXProperties>> |  |  |
+| All a| Any | All the properties of the JMS message as a flattened map. |  | x
+| User Properties a| Any | The user provided properties of the JMS message.  |  | x
+| Jms Properties a| Any | JMS message broker and provider properties. |  | x
+| Jmsx Properties a| <<JMSXProperties>> | JMSX properties of the JMS message  |  |
 |===
 
 [[JMSXProperties]]
@@ -512,14 +512,14 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Jmsx User ID a| String |  |  |
-| Jmsx App ID a| String |  |  |
-| Jmsx Delivery Count a| Number |  |  |
-| Jmsx Group ID a| String |  |  |
-| Jmsx Group Seq a| Number |  |  |
-| Jmsx Producer TXID a| String |  |  |
-| Jmsx Consumer TXID a| String |  |  |
-| Jmsx Rcv Timestamp a| Number |  |  |
+| Jmsx User ID a| String | The user identity that sends the message. |  |
+| Jmsx App ID a| String | The application identity that sends the message |  |
+| Jmsx Delivery Count a| Number | The number of message delivery attempts. |  |
+| Jmsx Group ID a| String | The message group identity the message is part of. |  |
+| Jmsx Group Seq a| Number | The sequence number of the message in the group. |  |
+| Jmsx Producer TXID a| String | The transaction identifier that produced the message. |  |
+| Jmsx Consumer TXID a| String | The transaction identifier that consumed the message |  |
+| Jmsx Rcv Timestamp a| Number | The time JMS delivered the message to the consumer. |  |
 |===
 
 [[RedeliveryPolicy]]
@@ -742,8 +742,8 @@ Used to configure the RedeliveryPolicy#getMaximumRedeliveries()
 | Custom JNDI Name Resolver a| One of:
 
 * <<SimpleJndiNameResolver>>
-* <<CachedJndiNameResolver>> |  |  |
-| Name Resolver Builder a| <<JndiNameResolverProperties>> |  |  |
+* <<CachedJndiNameResolver>> | Reference to a custom JndiNameResolver implementation |  |
+| Name Resolver Builder a| <<JndiNameResolverProperties>> | Properties required to build a SimpleJndiNameResolver |  |
 |===
 
 [[JndiNameResolverProperties]]
@@ -752,9 +752,9 @@ Used to configure the RedeliveryPolicy#getMaximumRedeliveries()
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Jndi Initial Context Factory a| String |  |  | x
-| Jndi Provider Url a| String |  |  |
-| Provider Properties a| Object |  |  |
+| Jndi Initial Context Factory a| String | The fully qualified class name of the factory class that creates an initial context. |  | x
+| Jndi Provider Url a| String | The JNDI service provider URL.  |  |
+| Provider Properties a| Object | Properties to pass to the JNDI Name Resolver Context |  |
 |===
 
 [[SimpleJndiNameResolver]]

--- a/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
@@ -491,7 +491,7 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 | Field | Type | Description | Default Value | Required
 | Properties a| <<JMSMessageProperties>> | Container element for all the properties present in a JMS Message. |  |
 | Headers a| Any | All the possible headers of a JMS message. |  | x
-| Ack Id a| String | The session Ack ID required to acknowledge at the current message if one is available, otherwise, is null.  |  |
+| Ack Id a| String | The session Ack ID required to acknowledge the current message if one is available, otherwise, is null.  |  |
 |===
 
 [[JMSMessageProperties]]
@@ -515,7 +515,7 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 | Jmsx User ID a| String | The user identity that sends the message. |  |
 | Jmsx App ID a| String | The application identity that sends the message |  |
 | Jmsx Delivery Count a| Number | The number of message delivery attempts. |  |
-| Jmsx Group ID a| String | The message group identity the message is part of. |  |
+| Jmsx Group ID a| String | The message group identity of the message. |  |
 | Jmsx Group Seq a| Number | The sequence number of the message in the group. |  |
 | Jmsx Producer TXID a| String | The transaction identifier that produced the message. |  |
 | Jmsx Consumer TXID a| String | The transaction identifier that consumed the message |  |

--- a/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
@@ -491,7 +491,7 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 | Field | Type | Description | Default Value | Required
 | Properties a| <<JMSMessageProperties>> | Container element for all the properties present in a JMS Message. |  |
 | Headers a| Any | All the possible headers of a JMS message. |  | x
-| Ack Id a| String | The session Ack ID required to acknowledge the current message if one is available, otherwise, is null.  |  |
+| Ack Id a| String | The session Ack ID required to acknowledge the current message if one is available, otherwise, it is null.  |  |
 |===
 
 [[JMSMessageProperties]]
@@ -503,7 +503,7 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 | All a| Any | All the properties of the JMS message as a flattened map. |  | x
 | User Properties a| Any | The user-provided properties of the JMS message.  |  | x
 | Jms Properties a| Any | JMS message broker and provider properties. |  | x
-| Jmsx Properties a| <<JMSXProperties>> | JMSX properties of the JMS message  |  |
+| Jmsx Properties a| <<JMSXProperties>> | JMSX properties of the JMS message.  |  |
 |===
 
 [[JMSXProperties]]
@@ -513,12 +513,12 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 |===
 | Field | Type | Description | Default Value | Required
 | Jmsx User ID a| String | The user identity that sends the message. |  |
-| Jmsx App ID a| String | The application identity that sends the message |  |
+| Jmsx App ID a| String | Identity of the application that sends the message. |  |
 | Jmsx Delivery Count a| Number | The number of message delivery attempts. |  |
 | Jmsx Group ID a| String | The message group identity of the message. |  |
 | Jmsx Group Seq a| Number | The sequence number of the message in the group. |  |
-| Jmsx Producer TXID a| String | The transaction identifier that produced the message. |  |
-| Jmsx Consumer TXID a| String | The transaction identifier that consumed the message |  |
+| Jmsx Producer TXID a| String | Identifier of the transaction that produced the message. |  |
+| Jmsx Consumer TXID a| String | Identifier of the transaction that consumed the message. |  |
 | Jmsx Rcv Timestamp a| Number | The time JMS delivered the message to the consumer. |  |
 |===
 
@@ -578,12 +578,12 @@ The maximum number of times a message can be redelivered and processed unsuccess
 |===
 | Field | Type | Description | Default Value | Required
 | Jmsx User ID a| String | The user identity that sends the message. |  |
-| Jmsx App ID a| String | The application identity that sends the message |  |
+| Jmsx App ID a| String | Identity of the application that sends the message. |  |
 | Jmsx Delivery Count a| Number | The number of message delivery attempts. |  |
 | Jmsx Group ID a| String | The message group identity of the message. |  |
 | Jmsx Group Seq a| Number | The sequence number of the message in the group. |  |
-| Jmsx Producer TXID a| String | The transaction identifier that produced the message. |  |
-| Jmsx Consumer TXID a| String | The transaction identifier that consumed the message |  |
+| Jmsx Producer TXID a| String | Identifier of the transaction that produced the message. |  |
+| Jmsx Consumer TXID a| String | Identifier of the transaction that consumed the message. |  |
 | Jmsx Rcv Timestamp a| Number | The time JMS delivered the message to the consumer. |  |
 |===
 

--- a/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
@@ -577,14 +577,14 @@ The maximum number of times a message can be redelivered and processed unsuccess
 [%header,cols="20s,25a,30a,15a,10a"]
 |===
 | Field | Type | Description | Default Value | Required
-| Jmsx User ID a| String |  |  |
-| Jmsx App ID a| String |  |  |
-| Jmsx Delivery Count a| Number |  |  |
-| Jmsx Group ID a| String |  |  |
-| Jmsx Group Seq a| Number |  |  |
-| Jmsx Producer TXID a| String |  |  |
-| Jmsx Consumer TXID a| String |  |  |
-| Jmsx Rcv Timestamp a| Number |  |  |
+| Jmsx User ID a| String | The user identity that sends the message. |  |
+| Jmsx App ID a| String | The application identity that sends the message |  |
+| Jmsx Delivery Count a| Number | The number of message delivery attempts. |  |
+| Jmsx Group ID a| String | The message group identity of the message. |  |
+| Jmsx Group Seq a| Number | The sequence number of the message in the group. |  |
+| Jmsx Producer TXID a| String | The transaction identifier that produced the message. |  |
+| Jmsx Consumer TXID a| String | The transaction identifier that consumed the message |  |
+| Jmsx Rcv Timestamp a| Number | The time JMS delivered the message to the consumer. |  |
 |===
 
 [[Tls]]


### PR DESCRIPTION
Adding missing descriptions in JMS Connector reference