### PR TITLE
Fix table format of MongoDB Find Documents

### DIFF
--- a/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -702,7 +702,7 @@ Finds all documents that match a given query. If no query is specified, all docu
 | Name | Type | Description | Default Value | Required
 | Configuration | String | The name of the configuration to use. | | x
 | Query a| Binary |  The optional query for finding documents. If unspecified, all documents are retrieved. Values can be: {"field1": "value1"} or can contain operators { "field1": { $gte: 1, $lt: 10 } }.|  |
-| Sort By a| Binary |  Indicates the document used to sort the results. Use {"yourField":"ASC"} to sort by ascending, or {"yourField":"DESC"} to sort by descending.|
+| Sort By a| Binary |  Indicates the document used to sort the results. Use {"yourField":"ASC"} to sort by ascending, or {"yourField":"DESC"} to sort by descending.|  |
 | Page Size a| Number |  Size of documents of each page to return |  100 |
 | Limit a| Number |  Limit of documents to return. |  |
 | Write Concern Acknowledgement a| String | The level of acknowledgment requested from MongoDB for Write operations propagated to the specified number of MongoDB instances. You can specify a number of instances, for example, `n>0`, or use a value from the list. |  |


### PR DESCRIPTION
There was a missing column for one row of the Find Documents operation of Mongo DB connector. It made that the following cells to be off by one.

Currently:

![image](https://user-images.githubusercontent.com/1738654/133478214-dd0c6d82-1b13-4a96-871a-88ba3d3326d7.png)
