### PR TITLE
Fix Mongo DB Update Documents default value placement

### DIFF
--- a/mongodb/6.0/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.0/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -1116,7 +1116,7 @@ Updates documents that match the specified query. If a query is not specified, a
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  The name of the collection to update |  | x
 | Query a| Binary |  The query object used to detect the element to update. The value can be: {"field1": "value1"}, or it can contain operators { "field1": { $gte: 1, $lt:  10 } }. |  |
-| Content To Update a| Binary |  The object to replace the one that matches the query |  | #payload
+| Content To Update a| Binary |  The object to replace the one that matches the query | #[payload] |
 | Multiple Update a| Boolean |  Indicates whether only the first document matching the query is updated |  false |
 | Upsert a| Boolean |  If set to true, creates a new document when no document matches the query criteria. The default value is false, which does not insert a new document when no match is found. |  false |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>

--- a/mongodb/6.1/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.1/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -1114,7 +1114,7 @@ Updates documents that match the specified query. If a query is not specified, a
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  The name of the collection to update |  | x
 | Query a| Binary |  The query object used to detect the element to update. The value can be: {"field1": "value1"}, or it can contain operators { "field1": { $gte: 1, $lt:  10 } }. |  |
-| Content To Update a| Binary |  The object to replace the one that matches the query |  | #payload
+| Content To Update a| Binary |  The object to replace the one that matches the query | #[payload] |
 | Multiple Update a| Boolean |  Indicates whether only the first document matching the query is updated |  false |
 | Upsert a| Boolean |  If set to true, creates a new document when no document matches the query criteria. The default value is false, which does not insert a new document when no match is found. |  false |
 | Streaming Strategy a| * <<repeatable-in-memory-stream>>

--- a/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.2/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -1181,7 +1181,7 @@ Updates documents that match the specified query. If a query is not specified, a
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  The name of the collection to update |  | x
 | Query a| Binary |  The query object used to detect the element to update. The value can be: {"field1": "value1"}, or it can contain operators { "field1": { $gte: 1, $lt:  10 } }. |  |
-| Content To Update a| Binary |  The object to replace the one that matches the query |  | #payload
+| Content To Update a| Binary |  The object to replace the one that matches the query | #[payload] |
 | Multiple Update a| Boolean |  Indicates whether only the first document matching the query is updated |  false |
 | Upsert a| Boolean |  If set to true, creates a new document when no document matches the query criteria. The default value is false, which does not insert a new document when no match is found. |  false |
 | Write Concern Acknowledgement a| String |The level of acknowledgment requested from MongoDB for Write operations propagated to the specified number of MongoDB instances. You can specify a number of instances, for example, `n>0`, or use a value from the list.  |  |

--- a/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -1221,7 +1221,7 @@ Updates documents that match the specified query. If a query is not specified, a
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  The name of the collection to update |  | x
 | Query a| Binary |  The query object used to detect the element to update. The value can be: {"field1": "value1"}, or it can contain operators { "field1": { $gte: 1, $lt:  10 } }. |  |
-| Content To Update a| Binary |  The object to replace the one that matches the query |  | #payload
+| Content To Update a| Binary |  The object to replace the one that matches the query | #[payload] | |
 | Multiple Update a| Boolean |  Indicates whether only the first document matching the query is updated |  false |
 | Upsert a| Boolean |  If set to true, creates a new document when no document matches the query criteria. The default value is false, which does not insert a new document when no match is found. |  false |
 | Write Concern Acknowledgement a| String |The level of acknowledgment requested from MongoDB for Write operations propagated to the specified number of MongoDB instances. You can specify a number of instances, for example, `n>0`, or use a value from the list.  |  |

--- a/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -1221,7 +1221,7 @@ Updates documents that match the specified query. If a query is not specified, a
 | Configuration | String | The name of the configuration to use. | | x
 | Collection Name a| String |  The name of the collection to update |  | x
 | Query a| Binary |  The query object used to detect the element to update. The value can be: {"field1": "value1"}, or it can contain operators { "field1": { $gte: 1, $lt:  10 } }. |  |
-| Content To Update a| Binary |  The object to replace the one that matches the query | #[payload] | |
+| Content To Update a| Binary |  The object to replace the one that matches the query | #[payload] | 
 | Multiple Update a| Boolean |  Indicates whether only the first document matching the query is updated |  false |
 | Upsert a| Boolean |  If set to true, creates a new document when no document matches the query criteria. The default value is false, which does not insert a new document when no match is found. |  false |
 | Write Concern Acknowledgement a| String |The level of acknowledgment requested from MongoDB for Write operations propagated to the specified number of MongoDB instances. You can specify a number of instances, for example, `n>0`, or use a value from the list.  |  |


### PR DESCRIPTION
For the field `Content To Update` of Mongo DB Update Documents the default value is shown in the `Required` column and with different format  than the rest.

Currently: 

![image](https://user-images.githubusercontent.com/1738654/133479208-06694a8b-d2d3-4f33-8c89-d8d1de54b342.png)
