### PR TITLE
W-10822550-connector-best-practices-partial-kt

### DIFF
--- a/connectors-home/modules/ROOT/pages/introduction/intro-connector-configuration-overview.adoc
+++ b/connectors-home/modules/ROOT/pages/introduction/intro-connector-configuration-overview.adoc
@@ -45,10 +45,7 @@ Each connector has different supported operations. To view a list of supported o
 
 The following best practices apply to configuring connectors:
 
-* Use a global element to define configuration details that can be shared with other instances of the connector in the flow.
-* Use property placeholders for property values if you are configuring a connector in Anypoint Studio or configuring it using XML outside the Studio editor.
-* Test the connectivity of a connector before you deploy it.
-* Configure a reconnection strategy to set the number of reconnection attempts to try after an initial failure.
+include::connectors::partial$configuration-best-practices.adoc[]
 
 [[global-element]]
 === Use a Global Element to Define Configuration Details

--- a/connectors-home/modules/ROOT/partials/configuration-best-practices.adoc
+++ b/connectors-home/modules/ROOT/partials/configuration-best-practices.adoc
@@ -1,0 +1,6 @@
+//Used in Anypoint Connector Configuration doc and Application Design Best Practices template
+
+* Use a global element to define configuration details that can be shared with other instances of the connector in the flow.
+* Use property-value placeholders to configure a connector in Anypoint Studio or to configure the connector using XML outside the Studio editor.
+* Configure a reconnection strategy to set the number of reconnection attempts to try after an initial failure.
+* When you finish the configuration, test the connectivity before you deploy it.


### PR DESCRIPTION
Moved configuration best practices to the partial folder and added include in the main Anypoint Connector Configuration doc. The partial will also be used in the upcoming new template Application Design Best Practices