### PR TITLE
[W-11256404] fix group id for dynamodb

### DIFF
--- a/amazon-dynamodb/1.4/antora.yml
+++ b/amazon-dynamodb/1.4/antora.yml
@@ -9,7 +9,7 @@ asciidoc:
     page-component-desc: Provides connectivity to the Amazon DynamoDB API.
     page-connector-type: Connector
     page-connector-level: Select
-    page-exchange-group-id: org.mulesoft.connectors
+    page-exchange-group-id: com.mulesoft.connectors
     page-exchange-asset-id: mule-amazon-dynamodb-connector
     page-release-notes-page: release-notes::connector/amazon-dynamodb-connector-release-notes-mule-4.adoc
     page-vendor-name: amazon


### PR DESCRIPTION
ref: [W-11256404](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11256404)

update the link to dynamodb. The current link, https://www.anypoint.mulesoft.com/exchange/org.mulesoft.connectors/mule-amazon-dynamodb-connector/, is a broken link, but after changing the group ID to com.mulesoft.connectors, https://www.anypoint.mulesoft.com/exchange/com.mulesoft.connectors/mule-amazon-dynamodb-connector/ is a working link.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
