### PR TITLE
remove duplicate alias

### DIFF
--- a/salesforce/10.15/modules/ROOT/pages/salesforce-connector-reference.adoc
+++ b/salesforce/10.15/modules/ROOT/pages/salesforce-connector-reference.adoc
@@ -1,5 +1,4 @@
 = Salesforce Connector 10.15 Reference - Mule 4
-:page-aliases: connectors::salesforce/salesforce-connector-reference.adoc
 include::reuse::partial$non-inclusive-banner.adoc[]
 
 Anypoint Connector for Salesforce (Salesforce Connector) enables you to accelerate your Salesforce integrations across Sales Cloud, Service Cloud, Salesforce Platform, and Force.com. This connector gives you access to all Salesforce entities to enable automation of your business processes to help maximize your investments in services and solutions, such as enabling your sales teams, increasing revenue, and serving your customers better.


### PR DESCRIPTION
This was causing a duplicate alias when performing a local build because the same alias exists in v10.16

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
