### PR TITLE
W-14851762 cloudhub conn limitation

### DIFF
--- a/cloudhub/1.2/modules/ROOT/pages/index.adoc
+++ b/cloudhub/1.2/modules/ROOT/pages/index.adoc
@@ -72,6 +72,12 @@ retrieve the available environments for easier configuration.
 
 image::cloudhub-environments-value-provider.gif[Available Environments]
 
+[NOTE]
+====
+The dropdown list will be populated with those environments belonging to the main business group of the configured credential's user.
+To use an environment from a child business group, that the same user has access to, manually specify its ID on either this field or corresponding XML attribute.
+====
+
 == Use the CloudHub Environment
 
 To specify the app deployment environment, use the <<environment.id-sysprop,`environment.id`>> system property.


### PR DESCRIPTION
There is a limitation on the environments displayed when configuring this connector.
It's not technically a bug but which API was used to build the connector.
Since changing this would be an enhancement let's call it out in the docs and let customers file an Idea in the portal to request it.