### PR TITLE
[W-14933910] Fix 3rd party connector icon on Connectors landing page

### DIFF
--- a/amazon-secrets-manager-properties-provider/1.0/antora.yml
+++ b/amazon-secrets-manager-properties-provider/1.0/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: com.mulesoft.module
-    page-exchange-asset-id: mule4-amazon-secrets-manager-properties-provider
+    page-exchange-asset-id: mule4-aws-secrets-manager-properties-provider
     page-runtime-version: 4.4.0
     page-release-notes-page: release-notes::connector/amazon-secrets-manager-properties-provider-release-notes-mule-4.adoc
     page-vendor-name: amazon


### PR DESCRIPTION
The [Connectors landing page](https://docs.mulesoft.com/connectors/) is displaying a broken icon for the Amazon Secrets Manager Connector. This PR updates the corresponding page attribute to fix this. 

![Screenshot 2024-02-19 at 11 13 11 AM](https://github.com/mulesoft/docs-connectors/assets/5760201/1edc7e09-569e-4494-bbb1-9a9f43da3454)

Broken image URL:
https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.module/mule4-amazon-secrets-manager-properties-provider/icon/svg

Fixed image URL:
https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.module/mule4-aws-secrets-manager-properties-provider/icon/svg

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
