### PR TITLE
@W-16025225 - Fix: Broken icons on archive connector landing page

### DIFF
--- a/bmc-remedy/0.3.8/antora.yml
+++ b/bmc-remedy/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Functions within a Mule application as a secure entrance for access and updates to your organization's information in the BMC Remedy AR System.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.connectors/mule-bmc-remedy-connector/icon/png/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/cloudhub/0.3.8/antora.yml
+++ b/cloudhub/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Enables you to create custom notifications inside your flows and exception strategies, as well as manage actions and alerts in your CloudHub instance.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.connectors/mule-cloudhub-connector/icon/svg/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/microsoft-dotnet/0.3.8/antora.yml
+++ b/microsoft-dotnet/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Allows you to call .NET code from a Mule flow.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.connectors/mule-microsoft-dotnet-connector/icon/svg/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/microsoft-dynamics-ax/0.3.8/antora.yml
+++ b/microsoft-dynamics-ax/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Enables Mule applications to interact with the Microsoft Dynamics AX Query Service.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.connectors/mule-microsoft-dynamics-ax-connector/icon/svg/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/microsoft-dynamics-gp/0.3.8/antora.yml
+++ b/microsoft-dynamics-gp/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Enables Mule apps to interact with the Microsoft Dynamics Great Plains (GP) Web Services.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.connectors/mule-microsoft-dynamics-gp-connector/icon/svg/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/microsoft-dynamics-nav/0.3.8/antora.yml
+++ b/microsoft-dynamics-nav/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Enables Mule applications to interact with Microsoft Dynamics NAV Web Services.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.connectors/mule-microsoft-dynamics-nav-connector/icon/svg/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/microsoft-sharepoint-2010/0.3.8/antora.yml
+++ b/microsoft-sharepoint-2010/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: A web app platform for content and document management, intranet portals, collaboration, extranets, websites, and enterprise search.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/org.mule.modules/mule-module-sharepoint-2010/icon/png/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/microsoft-sharepoint-2013/0.3.8/antora.yml
+++ b/microsoft-sharepoint-2013/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: A web app platform for content and document management, intranet portals, collaboration, extranets, websites, and enterprise search.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/org.mule.modules/mule-module-sharepoint/icon/png/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/sftp/0.3.8/antora.yml
+++ b/sftp/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Implements a secure file transport channel so that your Mule application can exchange files with external resources.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/org.mule.connectors/mule-sftp-connector/icon/svg/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules

--- a/windows-powershell/0.3.8/antora.yml
+++ b/windows-powershell/0.3.8/antora.yml
@@ -7,6 +7,8 @@ nav:
 asciidoc:
   attributes:
     page-component-desc: Enables Windows OS administration tasks to be integrated into Mule applications.
+    page-connector-icon-override: true
+    page-connector-icon-url: 'https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/com.mulesoft.connectors/mule-powershell-connector/icon/svg/'
     page-connector-type: Connector
     page-connector-level: Select
     page-exchange-group-id: org.mule.modules


### PR DESCRIPTION
The [archive connectors landing page](https://archive.docs.mulesoft.com/connectors/) has several broken icons. Unfortunately, the exchange URLs are generated based on the same group and asset IDs used for the icons, so you can't update those attributes without breaking the exchange links.

I've recently added some attributes that we can use to override icons specifically for this case (see https://github.com/mulesoft/docs-site-ui/pull/742). Now, you can add these attributes:
  * `page-connector-icon-override`. Set to true to use the generic connector icon.
  * `page-connector-icon-url`. Provide a hardcoded image URL to use instead of the generic icon.

This PR adds these attributes to fix the currently broken icons on the archive site.

**Before and after:**

<img width="314" alt="Screenshot 2024-06-18 at 6 24 00 PM" src="https://github.com/mulesoft/docs-connectors/assets/5760201/16c2fa77-5004-4060-b692-ef0a5e014058">
<img width="310" alt="Screenshot 2024-06-18 at 6 46 29 PM" src="https://github.com/mulesoft/docs-connectors/assets/5760201/8f8ce9d9-80ba-496a-b481-e43404929657">

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
