### PR TITLE
Update sap-connector-reference.adoc

### DIFF
--- a/sap/5.9/modules/ROOT/pages/sap-connector-reference.adoc
+++ b/sap/5.9/modules/ROOT/pages/sap-connector-reference.adoc
@@ -13,6 +13,7 @@ Starting with version 5.0, SAP Connector also supports connecting to an on-premi
 * The *Document Listener* and *Function Listener* sources do not support Mule transactions. Although the *Transactional action* and *Transaction type* parameters (on the *Advanced tab*) are available for both sources, the transactional feature is not implemented.
 * The reconnection strategy on SAP Listeners (*Document Listener* and *Function Listener*) relies exclusively on the JCo library, which means that the Mule reconnection mechanism has no impact on reconnections.
 * The JCO Server that runs in the background manages the reconnection when there is a connection issue. The JCo RFC provider recognizes a communication error between the Java server and the ABAP gateway and attempts to reconnect. If the first reconnection fails, the next reconnection attempt occurs after waiting for one second. If the reconnection fails again, the reconnection wait time doubles from one second to two seconds, until eventually it reaches the default maximum waiting period of 3600 seconds, or one hour. Set the maximum reconnection timeout using the `-Djco.server.max_startup_delay=<reconnect delay in seconds>` JMV parameter.
+* The `XSTRING` data format in SAP is a binary blop format.  To submit values in an `XSTRING` field you must use the [toHex](https://docs.mulesoft.com/dataweave/latest/dw-numbers-functions-tohex) function to base 32 encode the binary within the XML submitted to the RFC step.
 
 [[sap]]
 == Configuration


### PR DESCRIPTION
The `XSTRING` data format in SAP is a binary blop format.  To submit values in an `XSTRING` field you must use the [toHex](https://docs.mulesoft.com/dataweave/latest/dw-numbers-functions-tohex) function to base 32 encode the binary within the XML submitted to the RFC step.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
