### PR TITLE
Draft 3 is outdated

### DIFF
--- a/json/2.5/modules/ROOT/pages/json-reference.adoc
+++ b/json/2.5/modules/ROOT/pages/json-reference.adoc
@@ -35,7 +35,7 @@ Default configuration
 
 Validates that the input content is compliant with a given schema. This operation supports referencing many schemas (using comma as a separator) which include each other.
 
-NOTE: JSON *Validate schema* operation supports schema versions Draft 3, Draft 4, Draft 6, Draft 7, Draft 2019-09, and Draft 2020-12. If you do not specify a draft version in the JSON schema node, the default version is Draft 04.
+NOTE: JSON *Validate schema* operation supports schema versions Draft 4, Draft 6, Draft 7, Draft 2019-09, and Draft 2020-12. If you do not specify a draft version in the JSON schema node, the default version is Draft 04.
 
 ==== Parameters
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]


### PR DESCRIPTION
Draft 4 was published "Published: 31-January-2013" (wow 10 Years ago). And so support for draft 3 should be stopped.
https://json-schema.org/specification-links#draft-3

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
