### PR TITLE
W-20283237-db-store-procedure-clarification-kt

### DIFF
--- a/db/1.10/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.10/modules/ROOT/pages/database-documentation.adoc
@@ -758,6 +758,10 @@ When working with pooling profiles and the Query Single operation, the connectio
 
 Invokes a stored procedure on the database.  When the stored procedure returns one or more ResultSet instances, results are not read all at once. Instead, results are automatically streamed to prevent performance and memory issues. This behavior means that pages of `_fetchSize_` rows are loaded lazily when needed. If the *Stored procedure* operation is performed inside a transaction (for example, in a *Try* scope component), and that transaction is closed before consuming the data, accessing the results that haven't been loaded will fail.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/db/1.11/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.11/modules/ROOT/pages/database-documentation.adoc
@@ -759,6 +759,10 @@ When working with pooling profiles and the Query Single operation, the connectio
 
 Invokes a stored procedure on the database.  When the stored procedure returns one or more ResultSet instances, results are not read all at once. Instead, results are automatically streamed to prevent performance and memory issues. This behavior means that pages of `_fetchSize_` rows are loaded lazily when needed. If the *Stored procedure* operation is performed inside a transaction (for example, in a *Try* scope component), and that transaction is closed before consuming the data, accessing the results that haven't been loaded will fail.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/db/1.12/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.12/modules/ROOT/pages/database-documentation.adoc
@@ -758,6 +758,10 @@ When working with pooling profiles and the Query Single operation, the connectio
 
 Invokes a stored procedure on the database.  When the stored procedure returns one or more ResultSet instances, results are not read all at once. Instead, results are automatically streamed to prevent performance and memory issues. This behavior means that pages of `_fetchSize_` rows are loaded lazily when needed. If the *Stored procedure* operation is performed inside a transaction (for example, in a *Try* scope component), and that transaction is closed before consuming the data, accessing the results that haven't been loaded will fail.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/db/1.13/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.13/modules/ROOT/pages/database-documentation.adoc
@@ -761,6 +761,10 @@ When working with pooling profiles and the Query Single operation, the connectio
 
 Invokes a stored procedure on the database.  When the stored procedure returns one or more ResultSet instances, results are not read all at once. Instead, results are automatically streamed to prevent performance and memory issues. This behavior means that pages of `_fetchSize_` rows are loaded lazily when needed. If the *Stored procedure* operation is performed inside a transaction (for example, in a *Try* scope component), and that transaction is closed before consuming the data, accessing the results that haven't been loaded will fail.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/db/1.14/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.14/modules/ROOT/pages/database-documentation.adoc
@@ -760,6 +760,10 @@ When working with pooling profiles and the Query Single operation, the connectio
 
 Invokes a stored procedure on the database. When the stored procedure returns one or more ResultSet instances, results are not read all at once. Instead, results are automatically streamed to prevent performance and memory issues. This behavior means that pages of `_fetchSize_` rows are loaded lazily when needed. If the *Stored procedure* operation is performed inside a transaction (for example, in a *Try* scope component), and that transaction is closed before consuming the data, accessing the results that haven't been loaded will fail.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/db/1.15/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.15/modules/ROOT/pages/database-documentation.adoc
@@ -736,6 +736,10 @@ Selects data from a database. Streaming is automatically applied to avoid preemp
 
 Invokes a Stored Procedure on the database.  When the stored procedure returns one or more ResultSet instances, streaming is automatically applied to avoid preemptive consumption of such results, which may lead to performance and memory issues.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/db/1.8/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.8/modules/ROOT/pages/database-documentation.adoc
@@ -693,6 +693,10 @@ When working with pooling profiles and the *Select* operation, the connection re
 
 Invokes a stored procedure on the database.  When the stored procedure returns one or more ResultSet instances, streaming is applied automatically to avoid preemptive consumption of the results, which may lead to performance and memory issues.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]

--- a/db/1.9/modules/ROOT/pages/database-documentation.adoc
+++ b/db/1.9/modules/ROOT/pages/database-documentation.adoc
@@ -752,6 +752,10 @@ When working with pooling profiles and the Query Single operation, the connectio
 
 Invokes a stored procedure on the database.  When the stored procedure returns one or more ResultSet instances, streaming is applied automatically to avoid preemptive consumption of the results, which may lead to performance and memory issues.
 
+[NOTE]
+====
+Database Connector doesn't support Oracle primitive LOB collections (for example, VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.
+====
 
 ==== Parameters
 [%header,cols="20s,20a,35a,20a,5a"]


### PR DESCRIPTION
Add documentation note clarifying that Database Connector doesn't support Oracle primitive LOB collections (VARRAY/NESTED TABLE of BLOB/CLOB) in stored procedures.

Updated versions: 1.8-1.15

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
