### PR TITLE
W-18886494-jms-ack-mode-default-kt

### DIFF
--- a/jms/1.0/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.0/modules/ROOT/pages/jms-connector-reference.adoc
@@ -392,7 +392,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages.
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK |  The Session ACK mode to use when consuming a message. |  |
+** DUPS_OK |  The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String |  JMS selector to use for filtering incoming messages. |  |
 | Inbound Content Type a| String |  The content type of the message body. |  |
 | Inbound Encoding a| String |  The inboundEncoding of the message body. |  |

--- a/jms/1.1/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.1/modules/ROOT/pages/jms-connector-reference.adoc
@@ -411,7 +411,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages.
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK |  The Session ACK mode to use when consuming a message. |  |
+** DUPS_OK |  The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String |  JMS selector to use for filtering incoming messages. |  |
 | Inbound Content Type a| String |  The content type of the message body. |  |
 | Inbound Encoding a| String |  The inboundEncoding of the message body. |  |

--- a/jms/1.10/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.10/modules/ROOT/pages/jms-connector-reference.adoc
@@ -384,7 +384,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK | The Session ACK mode to use when consuming a message |  |
+** DUPS_OK | The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String | JMS selector to use for filtering incoming messages |  |
 | Inbound Content-Type a| String | The content type of the message body |  |
 | Inbound Encoding a| String | The inboundEncoding of the message body |  |

--- a/jms/1.2/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.2/modules/ROOT/pages/jms-connector-reference.adoc
@@ -393,7 +393,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages.
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK |  The Session ACK mode to use when consuming a message. |  |
+** DUPS_OK |  The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String |  JMS selector to use for filtering incoming messages. |  |
 | Inbound Content Type a| String |  The content type of the message body. |  |
 | Inbound Encoding a| String |  The inboundEncoding of the message body. |  |

--- a/jms/1.3/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.3/modules/ROOT/pages/jms-connector-reference.adoc
@@ -409,7 +409,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages.
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK |  The Session ACK mode to use when consuming a message. |  |
+** DUPS_OK |  The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String |  JMS selector to use for filtering incoming messages. |  |
 | Inbound Content-Type a| String |  The content type of the message body. |  |
 | Inbound Encoding a| String |  The inboundEncoding of the message body. |  |

--- a/jms/1.4/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.4/modules/ROOT/pages/jms-connector-reference.adoc
@@ -393,7 +393,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK |  The Session ACK mode to use when consuming a message |  |
+** DUPS_OK |  The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String |  JMS selector to use for filtering incoming messages |  |
 | Inbound Content-Type a| String |  The content type of the message body |  |
 | Inbound Encoding a| String |  The inboundEncoding of the message body |  |

--- a/jms/1.5/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.5/modules/ROOT/pages/jms-connector-reference.adoc
@@ -393,7 +393,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK |  The Session ACK mode to use when consuming a message |  |
+** DUPS_OK |  The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String |  JMS selector to use for filtering incoming messages |  |
 | Inbound Content-Type a| String |  The content type of the message body |  |
 | Inbound Encoding a| String |  The inboundEncoding of the message body |  |

--- a/jms/1.6/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.6/modules/ROOT/pages/jms-connector-reference.adoc
@@ -386,7 +386,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK | The Session ACK mode to use when consuming a message |  |
+** DUPS_OK | The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String | JMS selector to use for filtering incoming messages |  |
 | Inbound Content-Type a| String | The content type of the message body |  |
 | Inbound Encoding a| String | The inboundEncoding of the message body |  |

--- a/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.7/modules/ROOT/pages/jms-connector-reference.adoc
@@ -387,7 +387,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK | The Session ACK mode to use when consuming a message |  |
+** DUPS_OK | The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String | JMS selector to use for filtering incoming messages |  |
 | Inbound Content-Type a| String | The content type of the message body |  |
 | Inbound Encoding a| String | The inboundEncoding of the message body |  |

--- a/jms/1.8/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.8/modules/ROOT/pages/jms-connector-reference.adoc
@@ -388,7 +388,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK | The Session ACK mode to use when consuming a message |  |
+** DUPS_OK | The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String | JMS selector to use for filtering incoming messages |  |
 | Inbound Content-Type a| String | The content type of the message body |  |
 | Inbound Encoding a| String | The inboundEncoding of the message body |  |

--- a/jms/1.9/modules/ROOT/pages/jms-connector-reference.adoc
+++ b/jms/1.9/modules/ROOT/pages/jms-connector-reference.adoc
@@ -383,7 +383,11 @@ JMS Subscriber for Destinations, allows to listen for incoming Messages
 ** IMMEDIATE
 ** AUTO
 ** MANUAL
-** DUPS_OK | The Session ACK mode to use when consuming a message |  |
+** DUPS_OK | The Session ACK mode to use when consuming a message. The acknowledgment mode is determined as follows: +
+
+* If the listener has ackMode="MANUAL", and the Config has ackMode="AUTO", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode="MANUAL", then the listener uses ackMode="MANUAL" +
+* If the listener has ackMode=null, and the Config has ackMode=null, then the listener uses ackMode="AUTO" (the consumer config default) |  |
 | Selector a| String | JMS selector to use for filtering incoming messages |  |
 | Inbound Content-Type a| String | The content type of the message body |  |
 | Inbound Encoding a| String | The inboundEncoding of the message body |  |


### PR DESCRIPTION
Add detailed explanation of how ACK mode default value is determined:
- Listener ackMode takes precedence over config ackMode when set
- Config ackMode is used when listener ackMode is null
- Defaults to AUTO when both are null

Addresses feedback on jms-connector-reference#listener section

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
