### PR TITLE
W-19625630-database-connector-example-error-kT

### DIFF
--- a/db/1.15/modules/ROOT/pages/database-stored-procedure.adoc
+++ b/db/1.15/modules/ROOT/pages/database-stored-procedure.adoc
@@ -241,6 +241,76 @@ In the XML editor, the `<db:stored-procedure>` configuration looks like this:
 </db:stored-procedure>
 ----
 
+=== Calling Stored Procedures with Output Parameters
+
+When calling a stored procedure that returns an output parameter, ensure there is no space between the opening curly brace `{` and the return parameter name. The syntax must be `{:returnParameterName = call ...}` without any whitespace.
+
+This example illustrates calling a stored procedure with output parameters:
+
+[source,xml,linenums]
+----
+CREATE PROCEDURE dbo.up_NOP_CreateAttachment
+    @NOP_ID INTEGER,
+    @Description VARCHAR(255),
+    @DetailDescription VARCHAR(255),
+    @DetailOriginalFileName VARCHAR(255),
+    @FileExtensionTypeCD VARCHAR(10),
+    @Attachment VARBINARY(MAX)
+AS
+BEGIN
+    -- Procedure logic here
+    RETURN @returnCode
+END
+----
+
+To configure the stored procedure operation:
+
+. In the *Stored procedure* operation configuration screen, set *SQL Query Text* to:
++
+`{:returnCode = call dbo.up_NOP_CreateAttachment(:NOP_ID, :Description, :DetailDescription, :DetailOriginalFileName, :FileExtensionTypeCD, :Attachment)}`
++
+[IMPORTANT]
+====
+Do not include a space between the opening curly brace `{` and the colon `:` before the return parameter name. The syntax `{ :returnCode = ...}` with a space causes an error: "Unable to detect function 'name'". Use `{:returnCode = ...}` without the space.
+====
+
+. Set the *Input parameters* field to:
++
+[source,dataweave,linenums]
+----
+{
+    'NOP_ID' : vars.metadataContent.NOPID as Number,
+    'Description' : vars.metadataContent.Description,
+    'DetailDescription' : vars.metadataContent.DetailDescription,
+    'DetailOriginalFileName' : vars.metadataContent.DetailOriginalFileName,
+    'FileExtensionTypeCD' : vars.metadataContent.FileExtensionTypeCD,
+    'Attachment' : payload as Binary
+}
+----
+
+. Set the *Output parameters* field to `Edit inline`.
+. Click the plus sign (*+*) to add a new value.
+. In the new window, set the *Key* field to `returnCode` and the *Type* field to `INTEGER`.
+
+In the XML editor, the `<db:stored-procedure>` configuration looks like this:
+[source,xml,linenums]
+----
+<db:stored-procedure doc:name="Stored procedure" config-ref="Database_Config">
+    <db:sql>{:returnCode = call dbo.up_NOP_CreateAttachment(:NOP_ID, :Description, :DetailDescription, :DetailOriginalFileName, :FileExtensionTypeCD, :Attachment)}</db:sql>
+    <db:input-parameters>#[{
+        'NOP_ID' : vars.metadataContent.NOPID as Number,
+        'Description' : vars.metadataContent.Description,
+        'DetailDescription' : vars.metadataContent.DetailDescription,
+        'DetailOriginalFileName' : vars.metadataContent.DetailOriginalFileName,
+        'FileExtensionTypeCD' : vars.metadataContent.FileExtensionTypeCD,
+        'Attachment' : payload as Binary
+    }]</db:input-parameters>
+    <db:output-parameters>
+        <db:output-parameter key="returnCode" type="INTEGER"></db:output-parameter>
+    </db:output-parameters>
+</db:stored-procedure>
+----
+
 == See Also
 
 * xref:database-connector-examples.adoc[Database Connector Examples]


### PR DESCRIPTION
- Add example for calling stored procedures with output parameters
- Document correct syntax: {:returnCode = call ...} (no space after {)
- Add IMPORTANT note warning about common syntax error
- Based on support case feedback about 'Unable to detect function' error

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
