### PR TITLE
W-22006044 Add Client Reconnect parameters to IBM MQ Connector 1.8 XM…

### DIFF
--- a/ibm-mq/1.8/modules/ROOT/pages/ibm-mq-xml-ref.adoc
+++ b/ibm-mq/1.8/modules/ROOT/pages/ibm-mq-xml-ref.adoc
@@ -815,6 +815,13 @@ Allows a user to perform a session recover when the AckMode#MANUAL mode is elect
 | Queue Manager a| String | The queue manager which is used when selecting a channel definition. |  |
 | Channel a| String | Name of the channel to connect to. |  |
 | Connection Name List a| String | Hosts to which the client attempts to reconnect to after its connection is broken. The connection name list is a comma-separated list of host and IP port pairs. |  |
+| Client Reconnect Options a| Enumeration, one of:
+
+** RECONNECT
+** RECONNECT_Q_MGR
+** AS_DEF
+** DISABLED | Controls the reconnection behavior for the IBM MQ client. `RECONNECT` allows reconnection to any queue manager in the cluster, which is required for IBM MQ Uniform Cluster automatic application balancing. `RECONNECT_Q_MGR` restricts reconnection to the same queue manager. Applies when a Connection Name List or CCDT is configured. | `RECONNECT` |
+| Client Reconnect Timeout a| Number | The maximum time in seconds that the client spends attempting to reconnect. Applies when Connection Name List is configured with multiple hosts. | `20` |
 |===
 
 [[default-caching]]


### PR DESCRIPTION
…L reference

Added two new parameters to the Client connection configuration:
- Client Reconnect Options: Controls reconnection behavior for IBM MQ Uniform Cluster automatic application balancing (RECONNECT, RECONNECT_Q_MGR, AS_DEF, DISABLED)
- Client Reconnect Timeout: Maximum reconnection timeout in seconds (default: 20)

These parameters enable dynamic client connection rebalancing across Queue Managers when configured with Connection Name List or CCDT.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
