### PR TITLE
W-22733724-Update Topic parameter in Publish Event operation for Salesforce Pub/Sub docs-sis

### DIFF
--- a/salesforce-pubsub/1.0/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
+++ b/salesforce-pubsub/1.0/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
@@ -318,7 +318,14 @@ Publishes the given list of events to the specified event topic. Only high-volum
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | Name of the configuration to use. | | x
-| Topic a| String | Topic for the event you want to publish. The format of the topic is `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.  |  | x
+| Topic a| String | Name of the topic used for message publishing. You can select the topic name from the list of available topics.
+
+Sample topic formats:
+
+* For a standard platform event: `+/event/EventName+`. For a custom platform event: `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.
+* For a change data capture channel that captures events for all selected entities: `+/data/ChangeEvents+`. For a single-entity channel: `+/data/{StandardObjectName}ChangeEvent+`.
+
+For more information, refer to the Salesforce documentation.  |  | x
 | Events a| Array of Object |  List of events to publish that match the schema of the current topic. |  `#[payload]` |
 | Config Ref a| ConfigurationProvider |  Name of the configuration used to execute this component. |  | x
 | Target Variable a| String |  Name of the variable that stores the operation's output. |  |

--- a/salesforce-pubsub/1.1/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
+++ b/salesforce-pubsub/1.1/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
@@ -368,7 +368,14 @@ Publishes the given list of events to the specified event topic. Only high-volum
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | Name of the configuration to use. | | x
-| Topic a| String | Topic for the event you want to publish. The format of the topic is `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.  |  | x
+| Topic a| String | Name of the topic used for message publishing. You can select the topic name from the list of available topics.
+
+Sample topic formats:
+
+* For a standard platform event: `+/event/EventName+`. For a custom platform event: `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.
+* For a change data capture channel that captures events for all selected entities: `+/data/ChangeEvents+`. For a single-entity channel: `+/data/{StandardObjectName}ChangeEvent+`.
+
+For more information, refer to the Salesforce documentation.  |  | x
 | Events a| Array of Object |  List of events to publish that match the schema of the current topic. |  `#[payload]` |
 | Config Ref a| ConfigurationProvider |  Name of the configuration used to execute this component. |  | x
 | Target Variable a| String |  Name of the variable that stores the operation's output. |  |

--- a/salesforce-pubsub/1.2/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
+++ b/salesforce-pubsub/1.2/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
@@ -456,7 +456,14 @@ Publishes the given list of events to the specified event topic. Only high-volum
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | Name of the configuration to use. | | x
-| Topic a| String | Topic for the event you want to publish. The format of the topic is `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.  |  | x
+| Topic a| String | Name of the topic used for message publishing. You can select the topic name from the list of available topics.
+
+Sample topic formats:
+
+* For a standard platform event: `+/event/EventName+`. For a custom platform event: `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.
+* For a change data capture channel that captures events for all selected entities: `+/data/ChangeEvents+`. For a single-entity channel: `+/data/{StandardObjectName}ChangeEvent+`.
+
+For more information, refer to the Salesforce documentation.  |  | x
 | Events a| Array of Object |  List of events to publish that match the schema of the current topic. |  `#[payload]` |
 | Config Ref a| ConfigurationProvider |  Name of the configuration used to execute this component. |  | x
 | Target Variable a| String |  Name of the variable that stores the operation's output. |  |

--- a/salesforce-pubsub/1.3/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
+++ b/salesforce-pubsub/1.3/modules/ROOT/pages/salesforce-pubsub-connector-reference.adoc
@@ -456,7 +456,14 @@ Publishes the given list of events to the specified event topic. Only high-volum
 |===
 | Name | Type | Description | Default Value | Required
 | Configuration | String | Name of the configuration to use. | | x
-| Topic a| String | Topic for the event you want to publish. The format of the topic is `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.  |  | x
+| Topic a| String | Name of the topic used for message publishing. You can select the topic name from the list of available topics.
+
+Sample topic formats:
+
+* For a standard platform event: `+/event/EventName+`. For a custom platform event: `+/event/EventName__e+`. For example, for `+Order_Event__e+`, the topic is `+/event/Order_Event__e+`.
+* For a change data capture channel that captures events for all selected entities: `+/data/ChangeEvents+`. For a single-entity channel: `+/data/{StandardObjectName}ChangeEvent+`.
+
+For more information, refer to the Salesforce documentation.  |  | x
 | Events a| Array of Object |  List of events to publish that match the schema of the current topic. |  `#[payload]` |
 | Config Ref a| ConfigurationProvider |  Name of the configuration used to execute this component. |  | x
 | Target Variable a| String |  Name of the variable that stores the operation's output. |  |


### PR DESCRIPTION
Expand the Topic parameter description in the Publish Event operation to document the supported topic formats for standard platform events, custom platform events, and change data capture channels (multi-entity and single-entity), per customer feedback that the existing description covered only the custom platform event format.

Applied to all four versioned references (1.0, 1.1, 1.2, 1.3) since the content is identical across versions.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
