### PR TITLE
@W-22933350-mongo-db-system-property-patch-kt

### DIFF
--- a/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -1613,6 +1613,23 @@ Configures the truststore for TLS.
 |===
 
 
+== System Properties
+
+You can configure the following system property for the connector:
+
+[%header,cols="55s,15a,30a"]
+|===
+| Property | Default | Description
+| `com.mulesoft.connector.mongo.skipIsoCoercionUnderOperatorKeys` | `false` | When set to `true`, ISO-8601 strings nested under MongoDB query operator keys (keys prefixed with `$`, such as `$match`, `$and`, `$or`, `$elemMatch`, `$expr`, and `$lte`) are passed through verbatim as strings instead of being auto-coerced to BSON Date values. Use this property only if you query String-typed date fields through operator expressions and the queries return empty results unexpectedly.
+|===
+
+[NOTE]
+====
+This system property applies JVM-wide to all connector configurations and operations, and takes effect only after a Mule app restart.
+
+If your app relies on ISO-8601 auto-coercion for fields that store genuine BSON Date values, use Extended JSON notation (`{"$date": "..."}`) or DataWeave date types instead of enabling this property.
+====
+
 == See Also
 
 * xref:connectors::introduction/introduction-to-anypoint-connectors.adoc[Introduction to Anypoint Connectors]

--- a/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
+++ b/mongodb/6.3/modules/ROOT/pages/mongodb-connector-reference.adoc
@@ -1615,7 +1615,7 @@ Configures the truststore for TLS.
 
 == System Properties
 
-You can configure the following system property for the connector:
+You can configure this system property for the MongoDB Connector:
 
 [%header,cols="55s,15a,30a"]
 |===
@@ -1625,7 +1625,7 @@ You can configure the following system property for the connector:
 
 [NOTE]
 ====
-This system property applies JVM-wide to all connector configurations and operations, and takes effect only after a Mule app restart.
+This system property applies JVM-wide to all MongoDB Connector configurations and operations, and takes effect only after a Mule app restart.
 
 If your app relies on ISO-8601 auto-coercion for fields that store genuine BSON Date values, use Extended JSON notation (`{"$date": "..."}`) or DataWeave date types instead of enabling this property.
 ====


### PR DESCRIPTION
## Summary

- Documents the new opt-in system property `com.mulesoft.connector.mongo.skipIsoCoercionUnderOperatorKeys` introduced in MongoDB Connector 6.3.13
- Adds a new `== System Properties` section to the MongoDB Connector 6.3 Reference page, following the same pattern as JMS connector reference docs
- Covers the property's default value (`false`), when to use it (queries on String-typed date fields returning empty results), and caveats (JVM-wide scope, restart required, Extended JSON alternative)

## GUS

[W-22933350](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bxVUzYAM/view)

## Test plan

- [ ] Verify the new `== System Properties` section renders correctly in the published reference page
- [ ] Confirm table columns (Property, Default, Description) display as expected
- [ ] Confirm the NOTE block renders with both caveats